### PR TITLE
feat: 프로젝트 공고 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/wagglex2/waggle/WaggleApplication.java
+++ b/src/main/java/com/wagglex2/waggle/WaggleApplication.java
@@ -2,9 +2,7 @@ package com.wagglex2.waggle;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing  // Entity의 생성일(createdAt)을 자동으로 관리하기 위함
 @SpringBootApplication
 public class WaggleApplication {
 	public static void main(String[] args) {

--- a/src/main/java/com/wagglex2/waggle/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/wagglex2/waggle/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.wagglex2.waggle.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing  // Entity의 생성일(createdAt) 수정일(updatedAt)을 자동으로 관리하기 위함
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
+++ b/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     // 404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_NOT_FOUND", "파일을 찾을 수 없습니다."),
+    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT_NOT_FOUND", "공고를 찾을 수 없습니다."),
     POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "POSITION_NOT_FOUND", "역할을 찾을 수 없습니다."),
     SKILL_NOT_FOUND(HttpStatus.NOT_FOUND, "SKILL_NOT_FOUND", "기술 스택을 찾을 수 없습니다."),
 

--- a/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
+++ b/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     // 404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_NOT_FOUND", "파일을 찾을 수 없습니다."),
-    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECRUITMENT_NOT_FOUND", "공고를 찾을 수 없습니다."),
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_NOT_FOUND", "프로젝트 공고를 찾을 수 없습니다."),
     POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "POSITION_NOT_FOUND", "역할을 찾을 수 없습니다."),
     SKILL_NOT_FOUND(HttpStatus.NOT_FOUND, "SKILL_NOT_FOUND", "기술 스택을 찾을 수 없습니다."),
 

--- a/src/main/java/com/wagglex2/waggle/domain/common/dto/response/BaseRecruitmentResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/dto/response/BaseRecruitmentResponseDto.java
@@ -1,0 +1,36 @@
+package com.wagglex2.waggle.domain.common.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
+import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseRecruitmentResponseDto {
+    private final Long id;
+    private final Long authorId;
+    private final String authorNickname;
+    private final RecruitmentCategory category;
+    // TODO profileImg
+    // TODO university - merge 후 University enum 반영
+    private final String title;
+    private final String content;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime deadline;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdAt;
+
+    private final RecruitmentStatus status;
+    private int viewCount;
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/common/dto/response/BaseRecruitmentResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/dto/response/BaseRecruitmentResponseDto.java
@@ -28,9 +28,5 @@ public class BaseRecruitmentResponseDto {
     private final LocalDateTime createdAt;
 
     private final RecruitmentStatus status;
-    private int viewCount;
-
-    public void increaseViewCount() {
-        this.viewCount++;
-    }
+    private final int viewCount;
 }

--- a/src/main/java/com/wagglex2/waggle/domain/common/dto/response/BaseRecruitmentResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/dto/response/BaseRecruitmentResponseDto.java
@@ -3,6 +3,7 @@ package com.wagglex2.waggle.domain.common.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import com.wagglex2.waggle.domain.user.entity.type.University;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,7 +18,7 @@ public class BaseRecruitmentResponseDto {
     private final String authorNickname;
     private final RecruitmentCategory category;
     // TODO profileImg
-    // TODO university - merge 후 University enum 반영
+    private final University university;
     private final String title;
     private final String content;
 

--- a/src/main/java/com/wagglex2/waggle/domain/common/type/Period.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/type/Period.java
@@ -1,5 +1,6 @@
 package com.wagglex2.waggle.domain.common.type;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
 import jakarta.persistence.Column;
@@ -11,10 +12,12 @@ import java.time.LocalDate;
 
 @Embeddable
 public record Period(
+        @JsonFormat(pattern = "yyyy-MM-dd")
         @NotNull(message = "시작일이 누락되었습니다.")
         @Column(name = "start_date", nullable = false)
         LocalDate startDate,
 
+        @JsonFormat(pattern = "yyyy-MM-dd")
         @NotNull(message = "종료일이 누락되었습니다.")
         @FutureOrPresent(message = "종료일은 오늘 이후여야 합니다.")
         @Column(name = "end_date", nullable = false)

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
@@ -3,6 +3,7 @@ package com.wagglex2.waggle.domain.project.controller;
 import com.wagglex2.waggle.common.response.ApiResponse;
 import com.wagglex2.waggle.common.security.CustomUserDetails;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectCreationRequestDto;
+import com.wagglex2.waggle.domain.project.dto.response.ProjectResponseDto;
 import com.wagglex2.waggle.domain.project.service.ProjectService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/projects")
@@ -30,5 +28,15 @@ public class ProjectController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.ok("프로젝트 공고를 성공적으로 등록하였습니다."));
+    }
+
+    @GetMapping("/{projectId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<ProjectResponseDto>> getProject(@PathVariable Long projectId) {
+        ProjectResponseDto responseDto = projectService.getProject(projectId);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok("프로젝트 공고를 성공적으로 조회하였습니다.", responseDto)
+        );
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectResponseDto.java
@@ -2,6 +2,8 @@ package com.wagglex2.waggle.domain.project.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wagglex2.waggle.domain.common.dto.response.BaseRecruitmentResponseDto;
+import com.wagglex2.waggle.domain.common.dto.response.PeriodResponseDto;
+import com.wagglex2.waggle.domain.common.dto.response.PositionInfoResponseDto;
 import com.wagglex2.waggle.domain.common.type.*;
 import com.wagglex2.waggle.domain.project.entity.Project;
 import com.wagglex2.waggle.domain.project.type.MeetingType;
@@ -12,22 +14,23 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProjectResponseDto extends BaseRecruitmentResponseDto {
     private final ProjectPurpose purpose;
     private final MeetingType meetingType;
-    private final Set<PositionParticipantInfo> positions;
+    private final Set<PositionInfoResponseDto> positions;
     private final Set<Skill> skills;
     private final Set<Integer> grades;
-    private final Period period;
+    private final PeriodResponseDto period;
 
     private ProjectResponseDto(
             Long id, Long authorId, String authorNickname, RecruitmentCategory category, University university,
             String title, String content, LocalDateTime deadline, LocalDateTime createdAt,
             RecruitmentStatus status, int viewCount, ProjectPurpose purpose, MeetingType meetingType,
-            Set<PositionParticipantInfo> positions, Set<Skill> skills, Set<Integer> grades, Period period
+            Set<PositionInfoResponseDto> positions, Set<Skill> skills, Set<Integer> grades, PeriodResponseDto period
     ) {
         super(id, authorId, authorNickname, category, university, title, content, deadline, createdAt, status, viewCount);
         this.purpose = purpose;
@@ -40,12 +43,16 @@ public class ProjectResponseDto extends BaseRecruitmentResponseDto {
 
     public static ProjectResponseDto fromEntity(Project project) {
         User author = project.getUser();
+        PeriodResponseDto period = PeriodResponseDto.from(project.getPeriod());
+        Set<PositionInfoResponseDto> positions = project.getPositions().stream()
+                .map(PositionInfoResponseDto::from)
+                .collect(Collectors.toSet());
 
         return new ProjectResponseDto(
                 project.getId(), author.getId(), author.getNickname(), project.getCategory(), author.getUniversity(),
                 project.getTitle(), project.getContent(), project.getDeadline(), project.getCreatedAt(),
                 project.getStatus(), project.getViewCount(), project.getPurpose(), project.getMeetingType(),
-                project.getPositions(), project.getSkills(), project.getGrades(), project.getPeriod()
+                positions, project.getSkills(), project.getGrades(), period
         );
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectResponseDto.java
@@ -1,0 +1,50 @@
+package com.wagglex2.waggle.domain.project.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wagglex2.waggle.domain.common.dto.response.BaseRecruitmentResponseDto;
+import com.wagglex2.waggle.domain.common.type.*;
+import com.wagglex2.waggle.domain.project.entity.Project;
+import com.wagglex2.waggle.domain.project.type.MeetingType;
+import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
+import com.wagglex2.waggle.domain.user.entity.User;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProjectResponseDto extends BaseRecruitmentResponseDto {
+    private final ProjectPurpose purpose;
+    private final MeetingType meetingType;
+    private final Set<PositionParticipantInfo> positions;
+    private final Set<Skill> skills;
+    private final Set<Integer> grades;
+    private final Period period;
+
+    private ProjectResponseDto(
+            Long id, Long authorId, String authorNickname, RecruitmentCategory category,
+            String title, String content, LocalDateTime deadline, LocalDateTime createdAt,
+            RecruitmentStatus status, int viewCount, ProjectPurpose purpose, MeetingType meetingType,
+            Set<PositionParticipantInfo> positions, Set<Skill> skills, Set<Integer> grades, Period period
+    ) {
+        super(id, authorId, authorNickname, category, title, content, deadline, createdAt, status, viewCount);
+        this.purpose = purpose;
+        this.meetingType = meetingType;
+        this.positions = positions;
+        this.skills = skills;
+        this.grades = grades;
+        this.period = period;
+    }
+
+    public static ProjectResponseDto fromEntity(Project project) {
+        User author = project.getUser();
+
+        return new ProjectResponseDto(
+                project.getId(), author.getId(), author.getNickname(), project.getCategory(),
+                project.getTitle(), project.getContent(), project.getDeadline(), project.getCreatedAt(),
+                project.getStatus(), project.getViewCount(), project.getPurpose(), project.getMeetingType(),
+                project.getPositions(), project.getSkills(), project.getGrades(), project.getPeriod()
+        );
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectResponseDto.java
@@ -7,6 +7,7 @@ import com.wagglex2.waggle.domain.project.entity.Project;
 import com.wagglex2.waggle.domain.project.type.MeetingType;
 import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
 import com.wagglex2.waggle.domain.user.entity.User;
+import com.wagglex2.waggle.domain.user.entity.type.University;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -23,12 +24,12 @@ public class ProjectResponseDto extends BaseRecruitmentResponseDto {
     private final Period period;
 
     private ProjectResponseDto(
-            Long id, Long authorId, String authorNickname, RecruitmentCategory category,
+            Long id, Long authorId, String authorNickname, RecruitmentCategory category, University university,
             String title, String content, LocalDateTime deadline, LocalDateTime createdAt,
             RecruitmentStatus status, int viewCount, ProjectPurpose purpose, MeetingType meetingType,
             Set<PositionParticipantInfo> positions, Set<Skill> skills, Set<Integer> grades, Period period
     ) {
-        super(id, authorId, authorNickname, category, title, content, deadline, createdAt, status, viewCount);
+        super(id, authorId, authorNickname, category, university, title, content, deadline, createdAt, status, viewCount);
         this.purpose = purpose;
         this.meetingType = meetingType;
         this.positions = positions;
@@ -41,7 +42,7 @@ public class ProjectResponseDto extends BaseRecruitmentResponseDto {
         User author = project.getUser();
 
         return new ProjectResponseDto(
-                project.getId(), author.getId(), author.getNickname(), project.getCategory(),
+                project.getId(), author.getId(), author.getNickname(), project.getCategory(), author.getUniversity(),
                 project.getTitle(), project.getContent(), project.getDeadline(), project.getCreatedAt(),
                 project.getStatus(), project.getViewCount(), project.getPurpose(), project.getMeetingType(),
                 project.getPositions(), project.getSkills(), project.getGrades(), project.getPeriod()

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
@@ -2,8 +2,15 @@ package com.wagglex2.waggle.domain.project.repository;
 
 import com.wagglex2.waggle.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Project p set p.viewCount = p.viewCount + 1 where p.id = :projectId")
+    void increaseViewCount(@Param("projectId") Long projectId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
@@ -12,5 +12,5 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     @Modifying(clearAutomatically = true)
     @Query("update Project p set p.viewCount = p.viewCount + 1 where p.id = :projectId")
-    void increaseViewCount(@Param("projectId") Long projectId);
+    int increaseViewCount(@Param("projectId") Long projectId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
@@ -1,7 +1,9 @@
 package com.wagglex2.waggle.domain.project.service;
 
 import com.wagglex2.waggle.domain.project.dto.request.ProjectCreationRequestDto;
+import com.wagglex2.waggle.domain.project.dto.response.ProjectResponseDto;
 
 public interface ProjectService {
     void createProject(Long userId, ProjectCreationRequestDto projectCreationRequestDto);
+    ProjectResponseDto getProject(Long projectId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -1,6 +1,9 @@
 package com.wagglex2.waggle.domain.project.service.serviceImpl;
 
+import com.wagglex2.waggle.common.error.ErrorCode;
+import com.wagglex2.waggle.common.exception.BusinessException;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectCreationRequestDto;
+import com.wagglex2.waggle.domain.project.dto.response.ProjectResponseDto;
 import com.wagglex2.waggle.domain.project.entity.Project;
 import com.wagglex2.waggle.domain.project.repository.ProjectRepository;
 import com.wagglex2.waggle.domain.project.service.ProjectService;
@@ -23,5 +26,18 @@ public class ProjectServiceImpl implements ProjectService {
         User user = userService.findById(userId);
         Project newProject = ProjectCreationRequestDto.toEntity(user, requestDto);
         projectRepository.save(newProject);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public ProjectResponseDto getProject(Long projectId) {
+        ProjectResponseDto responseDto = projectRepository.findById(projectId)
+                .map(ProjectResponseDto::fromEntity)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RECRUITMENT_NOT_FOUND));
+
+        projectRepository.increaseViewCount(projectId);
+        responseDto.increaseViewCount();  // 조회 요청도 조회수에 포함
+
+        return responseDto;
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/user/entity/type/University.java
+++ b/src/main/java/com/wagglex2/waggle/domain/user/entity/type/University.java
@@ -1,7 +1,6 @@
 package com.wagglex2.waggle.domain.user.entity.type;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
 import lombok.Getter;
@@ -21,7 +20,6 @@ public enum University {
 
     private final String desc;
 
-    @JsonIgnore
     private final String domain;
 
     public  String getName() {

--- a/src/main/java/com/wagglex2/waggle/domain/user/entity/type/University.java
+++ b/src/main/java/com/wagglex2/waggle/domain/user/entity/type/University.java
@@ -1,6 +1,7 @@
 package com.wagglex2.waggle.domain.user.entity.type;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
 import lombok.Getter;
@@ -19,6 +20,8 @@ public enum University {
     KEIMYUNG_UNIV("계명대", "stu.kmu.ac.kr");
 
     private final String desc;
+
+    @JsonIgnore
     private final String domain;
 
     public  String getName() {

--- a/src/test/java/com/wagglex2/waggle/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/controller/ProjectControllerTest.java
@@ -77,10 +77,7 @@ class ProjectControllerTest {
 
         // then
         // code, message 제외, data만 추출
-        String actualJson = objectMapper.readTree(responseJson)
-                .get("data")
-
-                .toString();
+        String actualJson = objectMapper.readTree(responseJson).get("data").toString();
         String expectedJson = objectMapper.writeValueAsString(responseDto);
         assertThat(actualJson).isEqualTo(expectedJson);
     }

--- a/src/test/java/com/wagglex2/waggle/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/controller/ProjectControllerTest.java
@@ -1,0 +1,114 @@
+package com.wagglex2.waggle.domain.project.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wagglex2.waggle.common.security.jwt.JwtUtil;
+import com.wagglex2.waggle.domain.common.type.*;
+import com.wagglex2.waggle.domain.project.dto.response.ProjectResponseDto;
+import com.wagglex2.waggle.domain.project.entity.Project;
+import com.wagglex2.waggle.domain.project.service.ProjectService;
+import com.wagglex2.waggle.domain.project.type.MeetingType;
+import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
+import com.wagglex2.waggle.domain.user.entity.User;
+import com.wagglex2.waggle.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+/*
+    MVC 관련 Bean만 로드하기 때문에,
+    @EnableJpaAuditing이 @SpringBootApplication과 동일 클래스에 있을 경우,
+    JPA 관련 Bean이 등록되지 않은 상태로 Auditing이 적용되면서
+    `JPA metamodel must not be empty!` 오류가 발생되어 테스트 정상 진행 불가
+*/
+@WebMvcTest(ProjectController.class)
+@ExtendWith(MockitoExtension.class)
+@AutoConfigureMockMvc(addFilters = false) // Security 필터 제거
+class ProjectControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProjectService projectService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("프로젝트 공고 조회 성공")
+    void getProject() throws Exception {
+        // given
+        Project project = createProject();
+        ProjectResponseDto responseDto = ProjectResponseDto.fromEntity(project);
+        given(projectService.getProject(1L)).willReturn(responseDto);
+
+        // when
+        String responseJson = mockMvc.perform(
+                get("/api/v1/projects/1")
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        // then
+        // code, message 제외, data만 추출
+        String actualJson = objectMapper.readTree(responseJson)
+                .get("data")
+
+                .toString();
+        String expectedJson = objectMapper.writeValueAsString(responseDto);
+        assertThat(actualJson).isEqualTo(expectedJson);
+    }
+
+    private Project createProject() {
+        User author = mock(User.class);
+        given(author.getId()).willReturn(1L);
+        given(author.getNickname()).willReturn("솔랑솔랑");
+
+        LocalDate startDate = LocalDate.of(2025, 9, 10);
+        LocalDate endDate = startDate.plusDays(10);
+        Period period = new Period(startDate, endDate);
+        LocalDateTime deadline = LocalDateTime.of(startDate, LocalTime.of(23, 59, 59));
+
+        return Project.builder()
+                .user(author)
+                .title("해커톤 팀원 구합니다.")
+                .content("카카오에서 개최하는 해커톤 같이 할 사람 구해요.")
+                .purpose(ProjectPurpose.HACKATHON)
+                .meetingType(MeetingType.HYBRID)
+                .positions(Set.of(
+                        new PositionParticipantInfo(PositionType.FRONT_END, new ParticipantInfo(3)),
+                        new PositionParticipantInfo(PositionType.BACK_END, new ParticipantInfo(3))
+                ))
+                .skills(Set.of(Skill.REACT, Skill.SPRING_BOOT))
+                .grades(Set.of(3, 4))
+                .period(period)
+                .deadline(deadline)
+                .build();
+    }
+}

--- a/src/test/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryTest.java
@@ -1,35 +1,54 @@
 package com.wagglex2.waggle.domain.project.repository;
 
+import com.wagglex2.waggle.common.config.JpaAuditingConfig;
 import com.wagglex2.waggle.domain.common.type.*;
 import com.wagglex2.waggle.domain.project.entity.Project;
 import com.wagglex2.waggle.domain.project.type.MeetingType;
 import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
+import com.wagglex2.waggle.domain.user.entity.User;
+import com.wagglex2.waggle.domain.user.entity.type.UserRoleType;
+import com.wagglex2.waggle.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 
+/*
+    Repository 관련 Bean만 로드하기 때문에,
+    JpaAuditingConfig를 import하지 않으면 @CreatedDate, @LastModifiedDate 등이 적용되지 않아
+    createdAt, updatedAt 필드가 null이 되어, 테스트 정상 진행 불가
+*/
+@Import(JpaAuditingConfig.class)
 @DataJpaTest
 class ProjectRepositoryTest {
     @Autowired
     ProjectRepository projectRepository;
 
+    @Autowired
+    UserRepository userRepository;
+
     @Test
     @DisplayName("Project 등록 시 모든 필드가 올바르게 저장되어야 한다.")
     void saveProject() {
         // given
+        User user = createUser();
+        userRepository.save(user);
+
         LocalDate startDate = LocalDate.now();
         LocalDate endDate = startDate.plusDays(10);
         Period period = new Period(startDate, endDate);
         LocalDateTime deadline = LocalDateTime.now().minusDays(3);
 
         Project project = Project.builder()
+                .user(user)
                 .title("해커톤 팀원 구합니다.")
                 .content("카카오에서 개최하는 해커톤 같이 할 사람 구해요.")
                 .purpose(ProjectPurpose.HACKATHON)
@@ -58,5 +77,75 @@ class ProjectRepositoryTest {
         assertThat(saved.getGrades()).containsExactlyInAnyOrderElementsOf(project.getGrades());
         assertThat(saved.getPeriod()).isEqualTo(project.getPeriod());
         assertThat(saved.getDeadline()).isEqualTo(project.getDeadline());
+    }
+
+    @Test
+    @DisplayName("프로젝트 id로 프로젝트 공고 조회 성공")
+    void findById() {
+        // given
+        Project project = createProject();
+        projectRepository.save(project);
+
+        // when
+        Optional<Project> found = projectRepository.findById(project.getId());
+
+        // then
+        assertThat(found).isNotEmpty();
+        assertThat(found.get()).usingRecursiveComparison().isEqualTo(project);
+    }
+
+    @Test
+    @DisplayName("조회수 증가 쿼리가 정상적으로 반영되어야 한다.")
+    void increaseViewCount() throws InterruptedException {
+        // given
+        Project project = createProject();
+        projectRepository.save(project);
+
+        // when
+        projectRepository.increaseViewCount(project.getId());
+        projectRepository.increaseViewCount(project.getId());
+
+
+        // then
+        Project updated = projectRepository.findById(project.getId()).get();
+        assertThat(updated.getViewCount()).isEqualTo(2);
+    }
+
+    private Project createProject() {
+        User user = createUser();
+        userRepository.save(user);
+
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = startDate.plusDays(10);
+        Period period = new Period(startDate, endDate);
+        LocalDateTime deadline = LocalDateTime.now().minusDays(3);
+
+        return Project.builder()
+                .user(user)
+                .title("해커톤 팀원 구합니다.")
+                .content("카카오에서 개최하는 해커톤 같이 할 사람 구해요.")
+                .purpose(ProjectPurpose.HACKATHON)
+                .meetingType(MeetingType.HYBRID)
+                .positions(Set.of(
+                        new PositionParticipantInfo(PositionType.FRONT_END, new ParticipantInfo(3)),
+                        new PositionParticipantInfo(PositionType.BACK_END, new ParticipantInfo(3))
+                ))
+                .skills(Set.of(Skill.REACT, Skill.SPRING_BOOT))
+                .grades(Set.of(3, 4))
+                .period(period)
+                .deadline(deadline)
+                .build();
+    }
+
+    private User createUser() {
+        return User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .email("email@email.com")
+                .role(UserRoleType.ROLE_USER)
+                .shortIntro("short intro")
+                .build();
+
     }
 }

--- a/src/test/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryTest.java
@@ -6,6 +6,7 @@ import com.wagglex2.waggle.domain.project.entity.Project;
 import com.wagglex2.waggle.domain.project.type.MeetingType;
 import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
 import com.wagglex2.waggle.domain.user.entity.User;
+import com.wagglex2.waggle.domain.user.entity.type.University;
 import com.wagglex2.waggle.domain.user.entity.type.UserRoleType;
 import com.wagglex2.waggle.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -143,8 +144,12 @@ class ProjectRepositoryTest {
                 .password("password")
                 .nickname("nickname")
                 .email("email@email.com")
+                .university(University.YOUNGNAM_UNIV)
+                .grade(3)
                 .role(UserRoleType.ROLE_USER)
                 .shortIntro("short intro")
+                .position(PositionType.FRONT_END)
+                .skills(Set.of(Skill.REACT, Skill.SPRING_BOOT))
                 .build();
 
     }

--- a/src/test/java/com/wagglex2/waggle/domain/project/service/ProjectServiceImplTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/service/ProjectServiceImplTest.java
@@ -39,6 +39,7 @@ class ProjectServiceImplTest {
         // given
         Project project = createProject();
         given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(projectRepository.increaseViewCount(1L)).willReturn(1);
 
         // when
         ProjectResponseDto actual = projectService.getProject(1L);
@@ -48,7 +49,6 @@ class ProjectServiceImplTest {
         assertThat(actual).usingRecursiveComparison()
                 .ignoringFields("viewCount")
                 .isEqualTo(expected);
-        assertThat(actual.getViewCount()).isEqualTo(1);
         verify(projectRepository, times(1)).findById(1L);
     }
 

--- a/src/test/java/com/wagglex2/waggle/domain/project/service/ProjectServiceImplTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/service/ProjectServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.wagglex2.waggle.domain.project.service;
+
+import com.wagglex2.waggle.domain.common.type.*;
+import com.wagglex2.waggle.domain.project.dto.response.ProjectResponseDto;
+import com.wagglex2.waggle.domain.project.entity.Project;
+import com.wagglex2.waggle.domain.project.repository.ProjectRepository;
+import com.wagglex2.waggle.domain.project.service.serviceImpl.ProjectServiceImpl;
+import com.wagglex2.waggle.domain.project.type.MeetingType;
+import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
+import com.wagglex2.waggle.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceImplTest {
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @InjectMocks
+    private ProjectServiceImpl projectService;
+
+    @Test
+    @DisplayName("저장된 프로젝트 공고 조회 성공")
+    void getProject() {
+        // given
+        Project project = createProject();
+        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+
+        // when
+        ProjectResponseDto actual = projectService.getProject(1L);
+
+        // then
+        ProjectResponseDto expected = ProjectResponseDto.fromEntity(project);
+        assertThat(actual).usingRecursiveComparison()
+                .ignoringFields("viewCount")
+                .isEqualTo(expected);
+        assertThat(actual.getViewCount()).isEqualTo(1);
+        verify(projectRepository, times(1)).findById(1L);
+    }
+
+    private Project createProject() {
+        User author = mock(User.class);
+        given(author.getId()).willReturn(1L);
+        given(author.getNickname()).willReturn("솔랑솔랑");
+
+        LocalDate startDate = LocalDate.of(2025, 9, 10);
+        LocalDate endDate = startDate.plusDays(10);
+        Period period = new Period(startDate, endDate);
+        LocalDateTime deadline = LocalDateTime.of(startDate, LocalTime.of(23, 59, 59));
+
+        return Project.builder()
+                .user(author)
+                .title("해커톤 팀원 구합니다.")
+                .content("카카오에서 개최하는 해커톤 같이 할 사람 구해요.")
+                .purpose(ProjectPurpose.HACKATHON)
+                .meetingType(MeetingType.HYBRID)
+                .positions(Set.of(
+                        new PositionParticipantInfo(PositionType.FRONT_END, new ParticipantInfo(3)),
+                        new PositionParticipantInfo(PositionType.BACK_END, new ParticipantInfo(3))
+                ))
+                .skills(Set.of(Skill.REACT, Skill.SPRING_BOOT))
+                .grades(Set.of(3, 4))
+                .period(period)
+                .deadline(deadline)
+                .build();
+    }
+}


### PR DESCRIPTION
- BaseRecruitmentResponseDto 및 ProjectResponseDto 생성
- Controller, Service, Repository 관련 메서드 추가
- 관련 테스트 추가
- Controller 단위 테스트 시, 원활한 테스트 진행을 위해 `@EnableJpaAuditing`를 JpaAuditingConfig로 분리