### PR TITLE
fix: 프로젝트 공고 등록 및 조회 기능 수정

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/common/type/ParticipantInfo.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/type/ParticipantInfo.java
@@ -3,10 +3,7 @@ package com.wagglex2.waggle.domain.common.type;
 import com.wagglex2.waggle.domain.common.dto.request.PositionInfoCreationRequestDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
 /**
@@ -25,6 +22,7 @@ import lombok.NoArgsConstructor;
  */
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
 @Getter
 @Embeddable
 public class ParticipantInfo {

--- a/src/main/java/com/wagglex2/waggle/domain/common/type/PositionParticipantInfo.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/type/PositionParticipantInfo.java
@@ -23,6 +23,7 @@ import lombok.*;
  */
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@EqualsAndHashCode
 @Getter
 @Embeddable
 public class PositionParticipantInfo {

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class ProjectController {
     private final ProjectService projectService;
 
-    @PostMapping("/")
+    @PostMapping
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Long>> createProject(
             @RequestBody @Valid ProjectCreationRequestDto requestDto,

--- a/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectResponseDto.java
@@ -11,48 +11,47 @@ import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.entity.type.University;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProjectResponseDto extends BaseRecruitmentResponseDto {
     private final ProjectPurpose purpose;
     private final MeetingType meetingType;
-    private final Set<PositionInfoResponseDto> positions;
-    private final Set<Skill> skills;
-    private final Set<Integer> grades;
+
+    @Setter
+    private Set<PositionInfoResponseDto> positions;
+
+    @Setter
+    private Set<Skill> skills;
+
+    @Setter
+    private Set<Integer> grades;
+
     private final PeriodResponseDto period;
 
     private ProjectResponseDto(
             Long id, Long authorId, String authorNickname, RecruitmentCategory category, University university,
             String title, String content, LocalDateTime deadline, LocalDateTime createdAt,
-            RecruitmentStatus status, int viewCount, ProjectPurpose purpose, MeetingType meetingType,
-            Set<PositionInfoResponseDto> positions, Set<Skill> skills, Set<Integer> grades, PeriodResponseDto period
+            RecruitmentStatus status, int viewCount, ProjectPurpose purpose, MeetingType meetingType, PeriodResponseDto period
     ) {
         super(id, authorId, authorNickname, category, university, title, content, deadline, createdAt, status, viewCount);
         this.purpose = purpose;
         this.meetingType = meetingType;
-        this.positions = positions;
-        this.skills = skills;
-        this.grades = grades;
         this.period = period;
     }
 
     public static ProjectResponseDto fromEntity(Project project) {
         User author = project.getUser();
         PeriodResponseDto period = PeriodResponseDto.from(project.getPeriod());
-        Set<PositionInfoResponseDto> positions = project.getPositions().stream()
-                .map(PositionInfoResponseDto::from)
-                .collect(Collectors.toSet());
 
         return new ProjectResponseDto(
                 project.getId(), author.getId(), author.getNickname(), project.getCategory(), author.getUniversity(),
                 project.getTitle(), project.getContent(), project.getDeadline(), project.getCreatedAt(),
-                project.getStatus(), project.getViewCount(), project.getPurpose(), project.getMeetingType(),
-                positions, project.getSkills(), project.getGrades(), period
+                project.getStatus(), project.getViewCount(), project.getPurpose(), project.getMeetingType(), period
         );
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
@@ -1,5 +1,7 @@
 package com.wagglex2.waggle.domain.project.repository;
 
+import com.wagglex2.waggle.domain.common.type.PositionParticipantInfo;
+import com.wagglex2.waggle.domain.common.type.Skill;
 import com.wagglex2.waggle.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -7,10 +9,30 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+import java.util.Set;
+
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
+    // 1. Project + User
+    @Query("SELECT p FROM Project p JOIN FETCH p.user u WHERE p.id = :id")
+    Optional<Project> findByIdWithUser(@Param("id") Long id);
+
+    // 2. Positions
+    @Query("SELECT pos FROM Project p JOIN p.positions pos WHERE p.id = :id")
+    Set<PositionParticipantInfo> findPositionsByProjectId(@Param("id") Long id);
+
+    // 3. Skills
+    @Query("SELECT s FROM Project p JOIN p.skills s WHERE p.id = :id")
+    Set<Skill> findSkillsByProjectId(@Param("id") Long id);
+
+    // 4. Grades
+    @Query("SELECT g FROM Project p JOIN p.grades g WHERE p.id = :id")
+    Set<Integer> findGradesByProjectId(@Param("id") Long id);
+
+
     @Modifying(clearAutomatically = true)
-    @Query("update Project p set p.viewCount = p.viewCount + 1 where p.id = :projectId")
-    int increaseViewCount(@Param("projectId") Long projectId);
+    @Query("update Project p set p.viewCount = p.viewCount + 1 where p.id = :id")
+    int increaseViewCount(@Param("id") Long id);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
@@ -33,6 +33,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
 
     @Modifying(clearAutomatically = true)
-    @Query("update Project p set p.viewCount = p.viewCount + 1 where p.id = :id")
+    @Query("UPDATE Project p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
     int increaseViewCount(@Param("id") Long id);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -2,7 +2,9 @@ package com.wagglex2.waggle.domain.project.service.serviceImpl;
 
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
+import com.wagglex2.waggle.domain.common.dto.response.PositionInfoResponseDto;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import com.wagglex2.waggle.domain.common.type.Skill;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectCreationRequestDto;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectUpdateRequestDto;
 import com.wagglex2.waggle.domain.project.dto.response.ProjectResponseDto;
@@ -16,6 +18,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -43,8 +48,27 @@ public class ProjectServiceImpl implements ProjectService {
             throw new BusinessException(ErrorCode.PROJECT_NOT_FOUND);
         }
 
-        return projectRepository.findById(projectId)
+        // 각 collection 정보는 추가 쿼리로 조회 후 dto에 추가
+        // Project 정보와 User 정보
+        ProjectResponseDto responseDto = projectRepository.findByIdWithUser(projectId)
                 .map(ProjectResponseDto::fromEntity).get();
+
+        // Position 정보
+        Set<PositionInfoResponseDto> positions = projectRepository.findPositionsByProjectId(projectId).stream()
+                .map(PositionInfoResponseDto::from)
+                .collect(Collectors.toSet());
+
+        // Skill 정보
+        Set<Skill> skills = projectRepository.findSkillsByProjectId(projectId);
+
+        // Grade 정보
+        Set<Integer> grades = projectRepository.findGradesByProjectId(projectId);
+
+        responseDto.setPositions(positions);
+        responseDto.setSkills(skills);
+        responseDto.setGrades(grades);
+
+        return responseDto;
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -51,7 +51,8 @@ public class ProjectServiceImpl implements ProjectService {
         // 각 collection 정보는 추가 쿼리로 조회 후 dto에 추가
         // Project 정보와 User 정보
         ProjectResponseDto responseDto = projectRepository.findByIdWithUser(projectId)
-                .map(ProjectResponseDto::fromEntity).get();
+                .map(ProjectResponseDto::fromEntity)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
 
         // Position 정보
         Set<PositionInfoResponseDto> positions = projectRepository.findPositionsByProjectId(projectId).stream()

--- a/src/test/java/com/wagglex2/waggle/domain/project/service/ProjectServiceImplTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/service/ProjectServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.wagglex2.waggle.domain.project.service;
 
+import com.wagglex2.waggle.domain.common.dto.response.PositionInfoResponseDto;
 import com.wagglex2.waggle.domain.common.type.*;
 import com.wagglex2.waggle.domain.project.dto.response.ProjectResponseDto;
 import com.wagglex2.waggle.domain.project.entity.Project;
@@ -20,6 +21,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
@@ -38,7 +40,10 @@ class ProjectServiceImplTest {
     void getProject() {
         // given
         Project project = createProject();
-        given(projectRepository.findById(1L)).willReturn(Optional.of(project));
+        given(projectRepository.findByIdWithUser(1L)).willReturn(Optional.of(project));
+        given(projectRepository.findPositionsByProjectId(1L)).willReturn(project.getPositions());
+        given(projectRepository.findSkillsByProjectId(1L)).willReturn(project.getSkills());
+        given(projectRepository.findGradesByProjectId(1L)).willReturn(project.getGrades());
         given(projectRepository.increaseViewCount(1L)).willReturn(1);
 
         // when
@@ -46,10 +51,20 @@ class ProjectServiceImplTest {
 
         // then
         ProjectResponseDto expected = ProjectResponseDto.fromEntity(project);
+        expected.setPositions(project.getPositions().stream()
+                .map(PositionInfoResponseDto::from).collect(Collectors.toSet()));
+        expected.setSkills(project.getSkills());
+        expected.setGrades(project.getGrades());
+
         assertThat(actual).usingRecursiveComparison()
                 .ignoringFields("viewCount")
                 .isEqualTo(expected);
-        verify(projectRepository, times(1)).findById(1L);
+
+        verify(projectRepository, times(1)).findByIdWithUser(1L);
+        verify(projectRepository, times(1)).findPositionsByProjectId(1L);
+        verify(projectRepository, times(1)).findSkillsByProjectId(1L);
+        verify(projectRepository, times(1)).findGradesByProjectId(1L);
+        verify(projectRepository, times(1)).increaseViewCount(1L);
     }
 
     private Project createProject() {


### PR DESCRIPTION
Postman을 통한 테스트 중 정상 동작하지 않는 오류 발견으로 인한 수정

### 등록
- Controller `@PostMapping` "/" 제거

### 조회
- join table이 많아, Project 엔티티 내 collection 필드는 따로 조회하여 dto에 setter로 추가
- Project entity 내 vo에 hashcode 및 equals 추가 (조회 시 오류 방지)
- 관련 내용 테스트 코드 수정
---
@d4eh0 대형님도 과제랑 스터디 확인부탁드려요.