### PR TITLE
feat: 프로젝트 공고 찜 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/bookmark/controller/BookmarkController.java
@@ -3,7 +3,11 @@ package com.wagglex2.waggle.domain.bookmark.controller;
 import com.wagglex2.waggle.common.response.ApiResponse;
 import com.wagglex2.waggle.common.security.CustomUserDetails;
 import com.wagglex2.waggle.domain.bookmark.service.BookmarkService;
+import com.wagglex2.waggle.domain.project.dto.response.ProjectSummaryResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -27,6 +31,20 @@ public class BookmarkController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.ok("공고를 찜 목록에 성공적으로 추가하였습니다.", bookmarkId));
+    }
+
+    @GetMapping("/projects")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Page<ProjectSummaryResponseDto>>> getBookmarkedProjectSummariesByUserId(
+            @PageableDefault(size = 9) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Page<ProjectSummaryResponseDto> bookmarkedProjects =
+                bookmarkService.getBookmarkedProjectsByUserId(userDetails.getUserId(), pageable);
+
+        return ResponseEntity.ok(
+                ApiResponse.ok("프로젝트 공고 찜 목록을 성공적으로 조회하였습니다.", bookmarkedProjects)
+        );
     }
 
     @DeleteMapping("/{bookmarkId}")

--- a/src/main/java/com/wagglex2/waggle/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/bookmark/repository/BookmarkRepository.java
@@ -1,11 +1,26 @@
 package com.wagglex2.waggle.domain.bookmark.repository;
 
 import com.wagglex2.waggle.domain.bookmark.entity.Bookmark;
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByUserIdAndRecruitmentId(Long userId, Long recruitmentId);
+
+    /**
+     * 특정 사용자가 북마크한 Recruitment ID를 조회한다.
+     */
+    @Query("""
+        SELECT b.recruitment.id FROM Bookmark b
+        WHERE b.user.id = :userId
+        AND b.recruitment.category = :category
+        ORDER BY b.recruitment.createdAt DESC
+    """)
+    Page<Long> findBookmarkedRecruitmentIdsByUserId(Long userId, RecruitmentCategory category, Pageable pageable);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/bookmark/service/BookmarkService.java
@@ -1,7 +1,12 @@
 package com.wagglex2.waggle.domain.bookmark.service;
 
+import com.wagglex2.waggle.domain.project.dto.response.ProjectSummaryResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface BookmarkService {
 
     Long createBookmark(Long userId, Long recruitmentId);
+    Page<ProjectSummaryResponseDto> getBookmarkedProjectsByUserId(Long userId, Pageable pageable);
     void deleteBookmark(Long userId, Long bookmarkId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/bookmark/service/serviceImpl/BookmarkServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/bookmark/service/serviceImpl/BookmarkServiceImpl.java
@@ -6,12 +6,20 @@ import com.wagglex2.waggle.domain.bookmark.entity.Bookmark;
 import com.wagglex2.waggle.domain.bookmark.repository.BookmarkRepository;
 import com.wagglex2.waggle.domain.bookmark.service.BookmarkService;
 import com.wagglex2.waggle.domain.common.service.RecruitmentService;
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
+import com.wagglex2.waggle.domain.project.dto.response.ProjectSummaryResponseDto;
+import com.wagglex2.waggle.domain.project.service.ProjectService;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -21,6 +29,7 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final UserService userService;
     private final RecruitmentService recruitmentService;
+    private final ProjectService projectService;
 
     @PreAuthorize("#userId == authentication.principal.userId")
     @Transactional
@@ -37,6 +46,20 @@ public class BookmarkServiceImpl implements BookmarkService {
         );
 
         return bookmarkRepository.save(newBookmark).getId();
+    }
+
+    @PreAuthorize("#userId == authentication.principal.userId")
+    @Override
+    public Page<ProjectSummaryResponseDto> getBookmarkedProjectsByUserId(Long userId, Pageable pageable) {
+        // 찜한 프로젝트 공고 id 조회
+        Page<Long> targetIds =
+                bookmarkRepository.findBookmarkedRecruitmentIdsByUserId(userId, RecruitmentCategory.PROJECT, pageable);
+
+        // targetIds에 해당하는 프로젝트 공고 정보 조회
+        List<ProjectSummaryResponseDto> projectSummaries =
+                projectService.getProjectSummariesByIds(targetIds.getContent());
+
+        return new PageImpl<>(projectSummaries, pageable, targetIds.getTotalElements());
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/bookmark/service/serviceImpl/BookmarkServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/bookmark/service/serviceImpl/BookmarkServiceImpl.java
@@ -55,6 +55,11 @@ public class BookmarkServiceImpl implements BookmarkService {
         Page<Long> targetIds =
                 bookmarkRepository.findBookmarkedRecruitmentIdsByUserId(userId, RecruitmentCategory.PROJECT, pageable);
 
+        // 조회할 공고가 없으면, 빈 리스트 반환
+        if (targetIds.getContent().isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, targetIds.getTotalElements());
+        }
+
         // targetIds에 해당하는 프로젝트 공고 정보 조회
         List<ProjectSummaryResponseDto> projectSummaries =
                 projectService.getProjectSummariesByIds(targetIds.getContent());

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryCustom.java
@@ -5,6 +5,8 @@ import com.wagglex2.waggle.domain.project.dto.response.ProjectSummaryResponseDto
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 /**
  * QueryDSL을 활용한 Project 커스텀 리포지토리
  */
@@ -16,5 +18,13 @@ public interface ProjectRepositoryCustom {
      * @param pageable  페이징 및 정렬 정보 ({@link org.springframework.data.domain.Pageable})
      * @return 조건에 맞는 프로젝트 요약 DTO 페이지 ({@link org.springframework.data.domain.Page}&lt;{@link ProjectSummaryResponseDto}&gt;)
      */
-    Page<ProjectSummaryResponseDto> findProjectSummaries(ProjectSearchCondition condition, Pageable pageable);
+    Page<ProjectSummaryResponseDto> getProjectSummaries(ProjectSearchCondition condition, Pageable pageable);
+
+    /**
+     * 주어진 Project ID 목록에 해당하는 프로젝트 요약 정보를 조회한다.
+     *
+     * @param projectIds 조회할 Project ID 목록
+     * @return 입력 순서에 맞춘 {@code List<ProjectSummaryResponseDto>}
+     */
+    List<ProjectSummaryResponseDto> getProjectSummariesByIds(List<Long> projectIds);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
@@ -109,6 +109,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 
         // 최종 응답 데이터 (불변 리스트)
         return projectIds.stream()
+                .filter(Objects::nonNull)
                 .map(responseDtoMap::get)
                 .toList();
     }

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
@@ -42,7 +42,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
      *     </ol>
      */
     @Override
-    public Page<ProjectSummaryResponseDto> findProjectSummaries(ProjectSearchCondition condition, Pageable pageable) {
+    public Page<ProjectSummaryResponseDto> getProjectSummaries(ProjectSearchCondition condition, Pageable pageable) {
         // 조건에 맞는 모든 Project 공고 id 조회
         List<Long> projectIds = queryFactory
                 .select(project.id)
@@ -59,6 +59,33 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                 .orderBy(project.createdAt.desc())
                 .fetch();
 
+        // 해당 id의 Project 공고 조회
+        List<ProjectSummaryResponseDto> content = getProjectSummariesByIds(projectIds);
+
+        // 조건을 만족하는 모든 프로젝트 엔티티의 개수를 구하는 쿼리
+        // 페이지의 총 개수를 제공하기 위함
+        JPAQuery<Long> countQuery = queryFactory
+                .select(project.count())
+                .from(project)
+                .where(
+                        eqPurpose(condition.purpose()),
+                        eqStatus(condition.status()),
+                        containsAnyKeyword(condition.keywords()),
+                        containsAnyPosition(condition.positions()),
+                        containsAnySkill(condition.skills())
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 주어진 Project ID 목록에 해당하는 프로젝트 요약 정보를 조회한다.
+     *
+     * @param projectIds 조회할 Project ID 목록
+     * @return 입력 순서에 맞춘 {@code List<ProjectSummaryResponseDto>}
+     */
+    @Override
+    public List<ProjectSummaryResponseDto> getProjectSummariesByIds(List<Long> projectIds) {
         // 해당 id에 대한 Project 정보 조회
         // collection 데이터를 group by로 묶어서 가져오기 위함
         Map<Long, ProjectSummaryResponseDto> responseDtoMap = queryFactory
@@ -85,24 +112,9 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                 );
 
         // 최종 응답 데이터 (불변 리스트)
-        List<ProjectSummaryResponseDto> content = projectIds.stream()
+        return projectIds.stream()
                 .map(responseDtoMap::get)
                 .toList();
-
-        // 조건을 만족하는 모든 프로젝트 엔티티의 개수를 구하는 쿼리
-        // 페이지의 총 개수를 제공하기 위함
-        JPAQuery<Long> countQuery = queryFactory
-                .select(project.count())
-                .from(project)
-                .where(
-                        eqPurpose(condition.purpose()),
-                        eqStatus(condition.status()),
-                        containsAnyKeyword(condition.keywords()),
-                        containsAnyPosition(condition.positions()),
-                        containsAnySkill(condition.skills())
-                );
-
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
     /**

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
@@ -43,17 +43,19 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
      */
     @Override
     public Page<ProjectSummaryResponseDto> getProjectSummaries(ProjectSearchCondition condition, Pageable pageable) {
+        // where문 조건
+        BooleanBuilder builder = new BooleanBuilder()
+                .and(eqPurpose(condition.purpose()))
+                .and(eqStatus(condition.status()))
+                .and(containsAnyKeyword(condition.keywords()))
+                .and(containsAnyPosition(condition.positions()))
+                .and(containsAnySkill(condition.skills()));
+
         // 조건에 맞는 모든 Project 공고 id 조회
         List<Long> projectIds = queryFactory
                 .select(project.id)
                 .from(project)
-                .where(
-                        eqPurpose(condition.purpose()),
-                        eqStatus(condition.status()),
-                        containsAnyKeyword(condition.keywords()),
-                        containsAnyPosition(condition.positions()),
-                        containsAnySkill(condition.skills())
-                )
+                .where(builder)
                 .offset(pageable.getOffset())  // page
                 .limit(pageable.getPageSize()) // size
                 .orderBy(project.createdAt.desc())
@@ -67,13 +69,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
         JPAQuery<Long> countQuery = queryFactory
                 .select(project.count())
                 .from(project)
-                .where(
-                        eqPurpose(condition.purpose()),
-                        eqStatus(condition.status()),
-                        containsAnyKeyword(condition.keywords()),
-                        containsAnyPosition(condition.positions()),
-                        containsAnySkill(condition.skills())
-                );
+                .where(builder);
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
@@ -8,10 +8,13 @@ import com.wagglex2.waggle.domain.project.dto.response.ProjectSummaryResponseDto
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ProjectService {
     Long createProject(Long userId, ProjectCreationRequestDto projectCreationRequestDto);
     ProjectDetailResponseDto getProject(Long projectId);
     Page<ProjectSummaryResponseDto> getProjectSummaries(ProjectSearchCondition condition, Pageable pageable);
+    List<ProjectSummaryResponseDto> getProjectSummariesByIds(List<Long> projectIds);
     void updateProject(Long userId, Long projectId, ProjectUpdateRequestDto updateDto);
     void deleteProject(Long userId, Long projectId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -81,7 +81,7 @@ public class ProjectServiceImpl implements ProjectService {
             ProjectSearchCondition condition,
             Pageable pageable
     ) {
-        return projectRepository.findProjectSummaries(condition, pageable);
+        return projectRepository.getProjectSummaries(condition, pageable);
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -82,6 +83,22 @@ public class ProjectServiceImpl implements ProjectService {
             Pageable pageable
     ) {
         return projectRepository.getProjectSummaries(condition, pageable);
+    }
+
+    /**
+     * 주어진 Project ID 목록에 해당하는 프로젝트 요약 정보를 조회한다.
+     * <p>
+     * <ul>
+     *      <li>컨트롤러 요청이 아닌 다른 서비스에서 호출하기 위한 메서드</li>
+     *      <li>반환 리스트는 입력된 ID 순서를 보장</li>
+     * </ul>
+     *
+     * @param projectIds 조회할 Project ID 목록
+     * @return 입력 ID 순서에 맞춘 {@code List<ProjectSummaryResponseDto>}
+     */
+    @Override
+    public List<ProjectSummaryResponseDto> getProjectSummariesByIds(List<Long> projectIds) {
+        return projectRepository.getProjectSummariesByIds(projectIds);
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")


### PR DESCRIPTION
feat: 공고 찜하기 API 구현(#29) PR 기반

- 기존 Project 목록 조회 로직을 `getProjectSummariesByIds` 메서드로 분리하여 재사용성 개선
- BookmarkService에서 사용할 수 있도록 구조 개선
- ProjectService에 `getProjectSummariesByIds` 메서드 추가
- 특정 사용자의 찜 목록에 포함된 프로젝트 공고 ID를 조회한 뒤, 해당 ID로 Project Summaries를 프로젝션하여 반환

---
\* merge 전 확인 (제가 까먹을까봐)
  - origin/develop으로 rebase
  - base branch develop으로 재설정