### PR TITLE
Merge | Fix: 팀 멤버 조회 API 구현 v2 (develop 기준 복원)

### DIFF
--- a/src/main/java/com/wagglex2/waggle/common/config/PaginationProperties.java
+++ b/src/main/java/com/wagglex2/waggle/common/config/PaginationProperties.java
@@ -1,0 +1,32 @@
+package com.wagglex2.waggle.common.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 페이지네이션(Pagination) 관련 글로벌 설정 클래스.
+ *
+ * <p>application.properties 외부 설정 파일에서 "pagination" prefix로 값을 주입받는다.</p>
+ *
+ * <h3>설명</h3>
+ * <ul>
+ *   <li><b>defaultSize</b> - 클라이언트가 size 파라미터를 전달하지 않았을 때의 기본 페이지 크기</li>
+ *   <li><b>maxSize</b> - 클라이언트가 요청할 수 있는 최대 페이지 크기 (DoS 방지 목적)</li>
+ *   <li><b>maxPageNumber</b> - 허용되는 최대 페이지 번호 (너무 깊은 페이지 요청 차단)</li>
+ * </ul>
+ *
+ * <h3>주의사항</h3>
+ * <ul>
+ *   <li>Spring Data JPA의 기본 Pageable은 잘못된 size/page 값을 교정(default로 바꿈)하므로,
+ *       예외로 막으려면 별도 Validator에서 검사해야 한다.</li>
+ * </ul>
+ */
+@Component
+@ConfigurationProperties(prefix = "pagination")
+@Getter
+public class PaginationProperties {
+    private int maxSize = 100;
+    private int defaultSize = 20;
+    private int maxPageNumber = 10000;
+}

--- a/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
+++ b/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
@@ -27,6 +27,10 @@ public enum ErrorCode {
     INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "INVALID_PAGE_NUMBER", "페이지 번호는 1 이상이어야 합니다"),
     INVALID_ENUM_VALUE(HttpStatus.BAD_REQUEST, "INVALID_ENUM_VALUE", "쿼리 파라미터 값이 유효하지 않습니다. 허용 가능한 값 목록을 확인해주세요."),
     MISMATCHED_RECRUITMENT_CATEGORY(HttpStatus.BAD_REQUEST, "MISMATCHED_RECRUITMENT_CATEGORY", "지원하려는 공고의 카테고리가 요청한 카테고리와 일치하지 않습니다."),
+    INVALID_SORT_PROPERTY(HttpStatus.BAD_REQUEST, "INVALID_SORT_PROPERTY", "잘못된 정렬 기준입니다."),
+    INVALID_SORT_DIRECTION(HttpStatus.BAD_REQUEST, "INVALID_SORT_DIRECTION", "정렬 방향은 asc 또는 desc만 가능합니다."),
+    PAGE_SIZE_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "PAGE_SIZE_OUT_OF_RANGE", "페이지 크기는 1 이상이어야 합니다."),
+    PAGE_INDEX_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "PAGE_INDEX_OUT_OF_RANGE", "페이지 번호는 0 이상이어야 합니다."),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),

--- a/src/main/java/com/wagglex2/waggle/common/validator/PageableValidator.java
+++ b/src/main/java/com/wagglex2/waggle/common/validator/PageableValidator.java
@@ -1,0 +1,88 @@
+package com.wagglex2.waggle.common.validator;
+
+import com.wagglex2.waggle.common.config.PaginationProperties;
+import com.wagglex2.waggle.common.error.ErrorCode;
+import com.wagglex2.waggle.common.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * PageableValidator
+ *
+ * <p>Pageable 요청 객체에 포함된 페이지 번호(page), 페이지 크기(size), 정렬(sort) 값을 검증하는 유틸리티 컴포넌트.</p>
+ *
+ * <h3>검증 목적</h3>
+ * <ul>
+ *   <li>비정상적인 페이지 크기(size < 1 등) 요청 차단</li>
+ *   <li>너무 큰 pageNumber 요청 제한 (DoS 방지)</li>
+ *   <li>허용되지 않은 정렬 필드로 인한 보안/성능 문제 방지</li>
+ * </ul>
+ *
+ * <p>Spring Data JPA의 Pageable은 잘못된 값이 들어와도 내부적으로 보정(기본값 20 등)을 수행하지만,
+ * API 정책상 명시적인 예외를 던져 클라이언트에 오류를 알려주는 것이 더 안전하다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class PageableValidator {
+
+    private final PaginationProperties paginationProperties;
+
+    public Pageable validate(Pageable pageable) {
+        validatePageSize(pageable.getPageSize());
+        validatePageNumber(pageable.getPageNumber());
+        return pageable;
+    }
+
+    public void validateSort(Pageable pageable, Set<String> allowedProperties) {
+        if (pageable.getSort().isUnsorted()) {
+            return;
+        }
+
+        Set<String> requestProperties = pageable.getSort().stream()
+                .map(Sort.Order::getProperty)
+                .collect(Collectors.toSet());
+
+        for (String property : requestProperties) {
+            if (!allowedProperties.contains(property)) {
+                throw new BusinessException(
+                        ErrorCode.INVALID_SORT_PROPERTY,
+                        String.format(
+                                "%s는 정렬할 수 없는 필드입니다. 허용된 필드: [%s]",
+                                property, String.join(", ", allowedProperties)
+                        )
+                );
+            }
+        }
+    }
+
+    private void validatePageSize(int pageSize) {
+        if (pageSize < 1) {
+            throw new BusinessException(
+                    ErrorCode.PAGE_SIZE_OUT_OF_RANGE,
+                    String.format("페이지 크기는 1 이상이어야 합니다. (요청: %d)", pageSize)
+            );
+        }
+    }
+
+    private void validatePageNumber(int pageNumber) {
+        if (pageNumber < 0) {
+            throw new BusinessException(
+                    ErrorCode.PAGE_INDEX_OUT_OF_RANGE,
+                    String.format("페이지 번호는 0 이상이어야 합니다. (요청: %d)", pageNumber)
+            );
+        }
+
+        if (pageNumber > paginationProperties.getMaxPageNumber()) {
+            throw new BusinessException(
+                    ErrorCode.PAGE_INDEX_OUT_OF_RANGE,
+                    String.format("페이지 번호는 최대 %d까지 가능합니다. (요청: %d)",
+                            paginationProperties.getMaxPageNumber(), pageNumber)
+            );
+        }
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
@@ -9,6 +9,10 @@ import com.wagglex2.waggle.domain.assignment.entity.Assignment;
 import com.wagglex2.waggle.domain.assignment.repository.AssignmentRepository;
 import com.wagglex2.waggle.domain.assignment.service.AssignmentService;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import com.wagglex2.waggle.domain.team.entity.Team;
+import com.wagglex2.waggle.domain.team.service.TeamService;
+import com.wagglex2.waggle.domain.team_member.entity.TeamMember;
+import com.wagglex2.waggle.domain.team_member.entity.type.TeamRole;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AssignmentServiceImpl implements AssignmentService {
     private final AssignmentRepository assignmentRepository;
     private final UserService userService;
+    private final TeamService teamService;
 
     @Transactional
     @Override
@@ -30,7 +35,14 @@ public class AssignmentServiceImpl implements AssignmentService {
         User user = userService.findById(userId);
         Assignment newAssignment = AssignmentCreationRequestDto.toEntity(user, requestDto);
 
-        return assignmentRepository.save(newAssignment).getId();
+        Long assignmentId = assignmentRepository.save(newAssignment).getId();
+
+        Team team = new Team(newAssignment);
+        TeamMember leader = new TeamMember(team, user, TeamRole.LEADER);
+        team.addMember(leader);
+        teamService.save(team);
+
+        return assignmentId;
     }
 
     @Transactional

--- a/src/main/java/com/wagglex2/waggle/domain/team/controller/TeamController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/controller/TeamController.java
@@ -1,0 +1,68 @@
+package com.wagglex2.waggle.domain.team.controller;
+
+import com.wagglex2.waggle.common.response.ApiResponse;
+import com.wagglex2.waggle.common.security.CustomUserDetails;
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
+import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import com.wagglex2.waggle.domain.team.dto.response.TeamResponseDto;
+import com.wagglex2.waggle.domain.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.*;
+
+import java.beans.PropertyEditorSupport;
+
+@RestController
+@RequestMapping("/api/v1/teams")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+
+    /**
+     * 사용자 본인의 팀 목록을 카테고리 및 상태별로 조회하는 컨트롤러 메서드.
+     *
+     * <ul>
+     *   <li>현재 로그인한 사용자의 ID를 기반으로, 본인이 속한 팀 목록을 조회한다.</li>
+     *   <li>카테고리(프로젝트/스터디/과제)와 모집 상태(모집 중/마감 등)에 따라 필터링한다.</li>
+     * </ul>
+     * </p>
+     *
+     * @param category      모집 카테고리 (PROJECT, STUDY, ASSIGNMENT) — 기본값: PROJECT
+     * @param status        모집 상태 (RECRUITING, CLOSED, CANCELED) — 기본값: RECRUITING
+     * @param pageable      페이지 및 정렬 정보 (기본: 3개씩, createdAt DESC)
+     * @return              조회된 팀 목록(Page 형태)
+     */
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Page<TeamResponseDto>>> getMyTeamByCategory(
+            @RequestParam(value = "category", defaultValue = "PROJECT") RecruitmentCategory category,
+            @RequestParam(value = "status", defaultValue = "RECRUITING") RecruitmentStatus status,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(
+                    size = 3,
+                    sort = "createdAt",
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable
+    ) {
+
+        Page<TeamResponseDto> data = teamService.getByUserIdAndCategoryAndStatus(
+                userDetails.getUserId(),
+                category,
+                status,
+                pageable
+        );
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.ok("팀 조회에 성공했습니다.", data));
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/team/dto/response/TeamResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/dto/response/TeamResponseDto.java
@@ -1,0 +1,88 @@
+package com.wagglex2.waggle.domain.team.dto.response;
+
+import com.wagglex2.waggle.domain.common.dto.response.PeriodResponseDto;
+import com.wagglex2.waggle.domain.common.entity.BaseRecruitment;
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
+import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import com.wagglex2.waggle.domain.project.entity.Project;
+import com.wagglex2.waggle.domain.study.entity.Study;
+import com.wagglex2.waggle.domain.team.entity.Team;
+import com.wagglex2.waggle.domain.team_member.dto.response.TeamMemberResponseDto;
+import com.wagglex2.waggle.domain.team_member.entity.TeamMember;
+
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * 팀(Team) 엔티티에 대한 응답 DTO.
+ *
+ * <p>
+ * 필드 설명
+ * <ul>
+ *   <li><b>id</b>: Team 식별자</li>
+ *   <li><b>recruitmentId</b>: 연결된 모집공고(BaseRecruitment) ID</li>
+ *   <li><b>recruitmentTitle</b>: 모집공고 제목</li>
+ *   <li><b>category</b>: 프로젝트/스터디/과제 구분</li>
+ *   <li><b>status</b>: 모집 상태 (RECRUITING, CLOSED, CANCELED 등)</li>
+ *   <li><b>period</b>: 모집공고의 기간 정보 (Project/Study에만 존재)</li>
+ *   <li><b>durationDays</b>: 기간 일수(끝 - 시작 일자 계산 결과)</li>
+ *   <li><b>leaderNickname</b>: 팀 리더(모집공고 작성자)의 닉네임</li>
+ *   <li><b>memberCount</b>: 팀 멤버 수</li>
+ *   <li><b>members</b>: 각 팀 멤버의 상세 정보 DTO 리스트</li>
+ * </ul>
+ * </p>
+ */
+public record TeamResponseDto(
+        Long id,
+        Long recruitmentId,
+        String recruitmentTitle,
+        RecruitmentCategory category,
+        RecruitmentStatus status,
+        PeriodResponseDto period,
+        Long durationDays,
+        String leaderNickname,
+        int memberCount,
+        List<TeamMemberResponseDto> members
+) {
+    public static TeamResponseDto fromEntity(Team team) {
+        BaseRecruitment recruitment = team.getRecruitment();
+        List<TeamMember> teamMembers = team.getMembers();
+
+        // Project/Study만 기간(Period)을 가지므로 타입 확인 후 변환
+        PeriodResponseDto periodResponseDto;
+        if (recruitment instanceof Project project) {
+            periodResponseDto = PeriodResponseDto.from(project.getPeriod());
+        } else if (recruitment instanceof Study study) {
+            periodResponseDto = PeriodResponseDto.from(study.getPeriod());
+        } else {
+            periodResponseDto = null;
+        }
+
+        // 기간 일수 계산
+        Long durationDays = null;
+        if (periodResponseDto != null) {
+            long days = ChronoUnit.DAYS.between(
+                    periodResponseDto.startDate(),
+                    periodResponseDto.endDate()
+            );
+            durationDays = days >= 0 ? days : null;
+        }
+
+        List<TeamMemberResponseDto> memberDtos = teamMembers.stream()
+                .map(TeamMemberResponseDto::fromEntity)
+                .toList();
+
+        return new TeamResponseDto(
+                team.getId(),
+                recruitment.getId(),
+                recruitment.getTitle(),
+                recruitment.getCategory(),
+                recruitment.getStatus(),
+                periodResponseDto,
+                durationDays,
+                recruitment.getUser().getNickname(),
+                team.getMembers().size(),
+                memberDtos
+                );
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/team/entity/Team.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/entity/Team.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -49,6 +50,8 @@ public class Team {
     private BaseRecruitment recruitment;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
+    @OrderBy("role ASC") // LEADER 우선
     private List<TeamMember> members = new ArrayList<>();
 
     @CreatedDate

--- a/src/main/java/com/wagglex2/waggle/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/repository/TeamRepository.java
@@ -1,9 +1,63 @@
 package com.wagglex2.waggle.domain.team.repository;
 
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
+import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.team.entity.Team;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    /**
+     * 특정 사용자가 생성한 모집공고(프로젝트/스터디/과제)에 속한 팀 목록을
+     * 카테고리(category) 및 상태(status) 기준으로 페이징 조회하는 쿼리.
+     *
+     * <p>
+     * <ul>
+     *   <li>Team 엔티티를 기준으로, 연관된 모집공고(BaseRecruitment)와 작성자(User)를 함께 조회한다.</li>
+     *   <li>카테고리(RecruitmentCategory)와 모집 상태(RecruitmentStatus)로 필터링한다.</li>
+     *   <li>N+1 문제를 방지하기 위해 EntityGraph를 사용하여 연관 엔티티를 즉시 로딩한다.</li>
+     * </ul>
+     * </p>
+     *
+     * @param userId   모집공고 작성자(User)의 ID
+     * @param category 모집 카테고리 (PROJECT, STUDY, ASSIGNMENT 등)
+     * @param status   모집 상태 (RECRUITING, CLOSED, CANCELED 등)
+     * @param pageable 페이지 번호, 크기, 정렬 기준 정보를 포함한 Pageable 객체
+     * @return         Page 형태로 감싼 Team 엔티티 목록
+     */
+    @EntityGraph(
+            attributePaths = {
+                    "recruitment",
+                    "recruitment.user",
+            },
+            type = EntityGraph.EntityGraphType.LOAD
+    )
+    @Query(
+            value = """
+                    SELECT DISTINCT t
+                    FROM Team t
+                    WHERE t.recruitment.category = :category
+                    AND t.recruitment.status = :status
+                    AND t.recruitment.user.id = :userId
+                    """,
+            countQuery = """
+                    SELECT COUNT(t)
+                    FROM Team t
+                    WHERE t.recruitment.category = :category
+                    AND t.recruitment.status = :status
+                    AND t.recruitment.user.id = :userId
+                    """)
+    Page<Team> findByUserIdAndCategoryAndStatus(
+            @Param("userId") Long userId,
+            @Param("category") RecruitmentCategory category,
+            @Param("status") RecruitmentStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/wagglex2/waggle/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/repository/TeamRepository.java
@@ -39,9 +39,9 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             type = EntityGraph.EntityGraphType.LOAD
     )
     Page<Team> findDistinctByRecruitmentCategoryAndRecruitmentStatusAndRecruitmentUserId(
-            @Param("category") RecruitmentCategory category,
-            @Param("status") RecruitmentStatus status,
-            @Param("userId") Long userId,
+            RecruitmentCategory category,
+            RecruitmentStatus status,
+            Long userId,
             Pageable pageable
     );
 }

--- a/src/main/java/com/wagglex2/waggle/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/repository/TeamRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -39,25 +38,10 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             },
             type = EntityGraph.EntityGraphType.LOAD
     )
-    @Query(
-            value = """
-                    SELECT DISTINCT t
-                    FROM Team t
-                    WHERE t.recruitment.category = :category
-                    AND t.recruitment.status = :status
-                    AND t.recruitment.user.id = :userId
-                    """,
-            countQuery = """
-                    SELECT COUNT(t)
-                    FROM Team t
-                    WHERE t.recruitment.category = :category
-                    AND t.recruitment.status = :status
-                    AND t.recruitment.user.id = :userId
-                    """)
-    Page<Team> findByUserIdAndCategoryAndStatus(
-            @Param("userId") Long userId,
+    Page<Team> findDistinctByRecruitmentCategoryAndRecruitmentStatusAndRecruitmentUserId(
             @Param("category") RecruitmentCategory category,
             @Param("status") RecruitmentStatus status,
+            @Param("userId") Long userId,
             Pageable pageable
     );
 }

--- a/src/main/java/com/wagglex2/waggle/domain/team/service/TeamService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/service/TeamService.java
@@ -1,7 +1,13 @@
 package com.wagglex2.waggle.domain.team.service;
 
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
+import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import com.wagglex2.waggle.domain.team.dto.response.TeamResponseDto;
 import com.wagglex2.waggle.domain.team.entity.Team;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface TeamService {
     void save(Team team);
+    Page<TeamResponseDto> getByUserIdAndCategoryAndStatus(Long userId, RecruitmentCategory category, RecruitmentStatus status, Pageable pageable);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/team/service/serviceImpl/TeamServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/service/serviceImpl/TeamServiceImpl.java
@@ -1,5 +1,6 @@
 package com.wagglex2.waggle.domain.team.service.serviceImpl;
 
+import com.wagglex2.waggle.common.validator.PageableValidator;
 import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.team.dto.response.TeamResponseDto;
@@ -12,12 +13,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TeamServiceImpl implements TeamService {
 
     private final TeamRepository teamRepository;
+    private final PageableValidator pageableValidator;
+
+    private static final Set<String> MY_TEAM_SORT_FIELDS =
+            Set.of("createdAt", "updatedAt", "id");
 
     @Override
     @Transactional
@@ -42,6 +49,9 @@ public class TeamServiceImpl implements TeamService {
             RecruitmentStatus status,
             Pageable pageable
     ) {
+
+        pageableValidator.validate(pageable);
+        pageableValidator.validateSort(pageable, MY_TEAM_SORT_FIELDS);
 
         Page<Team> teams = teamRepository.findDistinctByRecruitmentCategoryAndRecruitmentStatusAndRecruitmentUserId(
                 category, status, userId, pageable

--- a/src/main/java/com/wagglex2/waggle/domain/team/service/serviceImpl/TeamServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/service/serviceImpl/TeamServiceImpl.java
@@ -43,8 +43,8 @@ public class TeamServiceImpl implements TeamService {
             Pageable pageable
     ) {
 
-        Page<Team> teams = teamRepository.findByUserIdAndCategoryAndStatus(
-                userId, category, status, pageable
+        Page<Team> teams = teamRepository.findDistinctByRecruitmentCategoryAndRecruitmentStatusAndRecruitmentUserId(
+                category, status, userId, pageable
         );
 
         teams.getContent().forEach(team -> {

--- a/src/main/java/com/wagglex2/waggle/domain/team/service/serviceImpl/TeamServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/service/serviceImpl/TeamServiceImpl.java
@@ -24,7 +24,7 @@ public class TeamServiceImpl implements TeamService {
     private final PageableValidator pageableValidator;
 
     private static final Set<String> MY_TEAM_SORT_FIELDS =
-            Set.of("createdAt", "updatedAt", "id");
+            Set.of("createdAt");
 
     @Override
     @Transactional

--- a/src/main/java/com/wagglex2/waggle/domain/team/service/serviceImpl/TeamServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/service/serviceImpl/TeamServiceImpl.java
@@ -1,9 +1,14 @@
 package com.wagglex2.waggle.domain.team.service.serviceImpl;
 
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
+import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import com.wagglex2.waggle.domain.team.dto.response.TeamResponseDto;
 import com.wagglex2.waggle.domain.team.entity.Team;
 import com.wagglex2.waggle.domain.team.repository.TeamRepository;
 import com.wagglex2.waggle.domain.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,5 +23,34 @@ public class TeamServiceImpl implements TeamService {
     @Transactional
     public void save(Team team) {
         teamRepository.save(team);
+    }
+
+    /**
+     * 특정 사용자가 생성한 모집공고(프로젝트/스터디 등)에 속한 팀 목록을
+     * 카테고리(category)와 상태(status)에 따라 페이징 조회하는 서비스 메서드.
+     *
+     * @param userId   모집공고 작성자(User)의 ID
+     * @param category 모집 카테고리 (PROJECT, STUDY, ASSIGNMENT 등)
+     * @param status   모집 상태 (RECRUITING, CLOSED, CANCELED 등)
+     * @param pageable 페이지 및 정렬 정보
+     * @return         Page 형태의 TeamResponseDto 목록
+     */
+    @Override
+    public Page<TeamResponseDto> getByUserIdAndCategoryAndStatus(
+            Long userId,
+            RecruitmentCategory category,
+            RecruitmentStatus status,
+            Pageable pageable
+    ) {
+
+        Page<Team> teams = teamRepository.findByUserIdAndCategoryAndStatus(
+                userId, category, status, pageable
+        );
+
+        teams.getContent().forEach(team -> {
+            team.getMembers().size(); // BatchSize 트리거
+        });
+
+        return teams.map(TeamResponseDto::fromEntity);
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/team_member/dto/response/TeamMemberResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team_member/dto/response/TeamMemberResponseDto.java
@@ -1,0 +1,36 @@
+package com.wagglex2.waggle.domain.team_member.dto.response;
+
+import com.wagglex2.waggle.domain.common.type.PositionType;
+import com.wagglex2.waggle.domain.team_member.entity.TeamMember;
+import com.wagglex2.waggle.domain.team_member.entity.type.TeamRole;
+
+/**
+ * 팀 멤버(TeamMember) 정보를 표현하는 응답 DTO.
+ *
+ * <p>
+ *  - 필드 설명
+ * <ul>
+ *   <li><b>userId</b> : 팀 멤버(User)의 고유 ID</li>
+ *   <li><b>nickname</b> : 사용자 닉네임</li>
+ *   <li><b>role</b> : 팀 내 역할 (LEADER, MEMBER 등, {@link TeamRole})</li>
+ *   <li><b>position</b> : 사용자의 포지션 (예: BACKEND, FRONTEND 등, {@link PositionType})</li>
+ *   <li><b>// TODO ProfileImage</b> : 추후 프로필 이미지 URL 추가 예정</li>
+ * </ul>
+ * </p>
+ */
+public record TeamMemberResponseDto(
+        Long userId,
+        // TODO ProfileImage
+        String nickname,
+        TeamRole role,
+        PositionType position
+) {
+    public static TeamMemberResponseDto fromEntity(TeamMember teamMember) {
+        return new TeamMemberResponseDto(
+                teamMember.getUser().getId(),
+                teamMember.getUser().getNickname(),
+                teamMember.getRole(),
+                teamMember.getPosition()
+        );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,8 @@ spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
 # loggin
 logging.level.org.hibernate.SQL=debug
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=trace
+
+# Pagination settings
+pagination.default-size=20
+pagination.max-size=100
+pagination.max-page-number=10000


### PR DESCRIPTION
이전 실수로 팀 생성 조회 API 구현 [BE-112] 코드가 팀 생성 API 구현 [BE-108]에 병합되어 develop에 반영되지 않아, 해당 커밋을 cherry-pick하여 develop 기준으로 복원한 브랜치입니다.

-  refactor: Assignment 생성 시 Team 및 TeamMember 추가
- 팀 멤버 조회 API 구현
- TeamRepository 리팩터링 (JPQL 제거)
- Pagination Parameter 예외 처리 추가
- 피드백 반영 수정

[BE-112]: https://2025-yu-se.atlassian.net/browse/BE-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BE-108]: https://2025-yu-se.atlassian.net/browse/BE-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ