### PR TITLE
feat: 지원 제출/수락/거절 알림 이벤트 처리

### DIFF
--- a/src/main/java/com/wagglex2/waggle/WaggleApplication.java
+++ b/src/main/java/com/wagglex2/waggle/WaggleApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
@@ -12,6 +13,7 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 // 엔티티를 직접 노출하지 않고, DTO 리스트 + 페이징 정보만 반환
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 @EnableRetry(proxyTargetClass = true)  // 낙관적 락 충돌 시 재시도를 위함
+@EnableAsync  // 이벤트 처리를 위함
 public class WaggleApplication {
 	public static void main(String[] args) {
         SpringApplication.run(WaggleApplication.class, args);

--- a/src/main/java/com/wagglex2/waggle/domain/application/event/ApplicationProcessedEvent.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/event/ApplicationProcessedEvent.java
@@ -1,0 +1,10 @@
+package com.wagglex2.waggle.domain.application.event;
+
+import com.wagglex2.waggle.domain.notification.type.NotificationType;
+
+public record ApplicationProcessedEvent(
+        Long senderId,
+        Long receiverId,
+        Long applicationId,
+        NotificationType type
+) { }

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -8,6 +8,7 @@ import com.wagglex2.waggle.domain.application.dto.response.ApplicationCommonResp
 import com.wagglex2.waggle.domain.application.dto.response.ApplicationProjectResponseDto;
 import com.wagglex2.waggle.domain.application.dto.response.ApplicationSimpleResponseDto;
 import com.wagglex2.waggle.domain.application.entity.Application;
+import com.wagglex2.waggle.domain.application.event.ApplicationProcessedEvent;
 import com.wagglex2.waggle.domain.application.repository.ApplicationRepository;
 import com.wagglex2.waggle.domain.application.service.ApplicationService;
 import com.wagglex2.waggle.domain.application.type.ApplicationStatus;
@@ -18,6 +19,7 @@ import com.wagglex2.waggle.domain.common.type.ParticipantInfo;
 import com.wagglex2.waggle.domain.common.type.PositionParticipantInfo;
 import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
+import com.wagglex2.waggle.domain.notification.type.NotificationType;
 import com.wagglex2.waggle.domain.project.entity.Project;
 import com.wagglex2.waggle.domain.study.entity.Study;
 import com.wagglex2.waggle.domain.team.entity.Team;
@@ -28,6 +30,7 @@ import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -48,6 +51,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     private final UserService userService;
     private final RecruitmentService recruitmentService;
     private final TeamService teamService;
+    private final ApplicationEventPublisher publisher;
 
     @PreAuthorize("#userId == authentication.principal.userId")
     @Transactional
@@ -85,11 +89,21 @@ public class ApplicationServiceImpl implements ApplicationService {
             throw new BusinessException(ErrorCode.ALREADY_APPLIED_RECRUITMENT);
         }
 
-        return switch (recruitment.getCategory()) {
+        Long applicationId = switch (recruitment.getCategory()) {
             case PROJECT -> applyProject(applicant, (Project) recruitment, (ApplicationProjectRequestDto) requestDto);
             case ASSIGNMENT -> applyAssignment(applicant, (Assignment) recruitment, requestDto);
             case STUDY -> applyStudy(applicant, (Study) recruitment, requestDto);
         };
+
+        // 이벤트 발행
+        publisher.publishEvent(new ApplicationProcessedEvent(
+                applicant.getId(),
+                recruitment.getUser().getId(),
+                applicationId,
+                NotificationType.APPLICATION_SUBMITTED
+        ));
+
+        return applicationId;
     }
 
     @Override
@@ -192,6 +206,14 @@ public class ApplicationServiceImpl implements ApplicationService {
         Team team = teamService.findByRecruitmentId(recruitment.getId());
         TeamMember newMember = new TeamMember(team, application.getApplicant(), TeamRole.MEMBER);
         team.addMember(newMember);
+
+        // 이벤트 발행
+        publisher.publishEvent(new ApplicationProcessedEvent(
+                deciderId,
+                application.getApplicant().getId(),
+                applicationId,
+                NotificationType.APPLICATION_ACCEPTED
+        ));
     }
 
     @PreAuthorize("#deciderId == authentication.principal.userId")
@@ -216,6 +238,14 @@ public class ApplicationServiceImpl implements ApplicationService {
 
         // 처리 로직
         application.reject();
+
+        // 이벤트 발행
+        publisher.publishEvent(new ApplicationProcessedEvent(
+                deciderId,
+                application.getApplicant().getId(),
+                applicationId,
+                NotificationType.APPLICATION_REJECTED
+        ));
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/event/NotificationEventListener.java
@@ -1,0 +1,37 @@
+package com.wagglex2.waggle.domain.notification.event;
+
+import com.wagglex2.waggle.domain.application.event.ApplicationProcessedEvent;
+import com.wagglex2.waggle.domain.notification.service.NotificationService;
+import com.wagglex2.waggle.domain.notification.type.NotificationType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * ApplicationProcessedEvent 수신 후 알림 생성
+ * <ul>
+ *     <li>Application 상태 변경 이벤트 수신</li>
+ *     <li>NotificationService를 통해 알림 생성</li>
+ *     <li>비동기 실행 및 트랜잭션 커밋 후 처리</li>
+ *     <li>처리 타입: {@link NotificationType}</li>
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void createNotification(ApplicationProcessedEvent event) {
+        notificationService.createNotification(
+                event.senderId(),
+                event.receiverId(),
+                event.applicationId(),
+                event.type()
+        );
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/service/NotificationService.java
@@ -16,6 +16,7 @@ public interface NotificationService {
      *
      * @param senderId 알림을 발생시킨 사용자 ID
      * @param receiverId 알림 수신자 ID
+     * @param applicationId 지원 ID
      * @param type 알림 타입
      */
     void createNotification(Long senderId, Long receiverId, Long applicationId, NotificationType type);


### PR DESCRIPTION
- 이벤트 처리는 각 서비스의 트랜잭션 커밋(`AFTER_COMMIT`) 이후 수행
- 알림 생성은 비동기(`@Async`)로 처리