### PR TITLE
fix: 공고 상세 조회 누락된 조건 추가

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/assignment/controller/AssignmentController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/controller/AssignmentController.java
@@ -44,8 +44,12 @@ public class AssignmentController {
 
     @GetMapping("/{assignmentId}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<APIResponse<AssignmentDetailResponseDto>> getAssignment(@PathVariable Long assignmentId) {
-        AssignmentDetailResponseDto responseDto = assignmentService.getAssignment(assignmentId);
+    public ResponseEntity<APIResponse<AssignmentDetailResponseDto>> getAssignment(
+            @PathVariable Long assignmentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AssignmentDetailResponseDto responseDto =
+                assignmentService.getAssignment(userDetails.getUserId(), assignmentId);
 
         return ResponseEntity.ok(
                 APIResponse.ok("과제 공고를 성공적으로 조회하였습니다.", responseDto)

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/dto/response/AssignmentDetailResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/dto/response/AssignmentDetailResponseDto.java
@@ -39,13 +39,13 @@ public class AssignmentDetailResponseDto extends BaseRecruitmentDetailResponseDt
     public static AssignmentDetailResponseDto fromEntity(Assignment assignment) {
         User author = assignment.getUser();
         ParticipantInfoResponseDto participants = ParticipantInfoResponseDto.from(assignment.getParticipants());
-
+        Set<Integer> grades = Set.copyOf(assignment.getGrades());
 
         return new AssignmentDetailResponseDto(
                 assignment.getId(), author.getId(), author.getNickname(), assignment.getCategory(), author.getUniversity(),
                 assignment.getTitle(), assignment.getContent(), assignment.getDeadline(), assignment.getCreatedAt(),
                 assignment.getStatus(), assignment.getViewCount(), assignment.getDepartment(), assignment.getLecture(),
-                assignment.getLectureCode(), participants, assignment.getGrades()
+                assignment.getLectureCode(), participants, grades
         );
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepository.java
@@ -1,14 +1,23 @@
 package com.wagglex2.waggle.domain.assignment.repository;
 
 import com.wagglex2.waggle.domain.assignment.entity.Assignment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AssignmentRepository extends JpaRepository<Assignment, Long>, AssignmentRepositoryCustom {
+
+    @EntityGraph(
+            attributePaths = {"user", "grades"},
+            type = EntityGraph.EntityGraphType.LOAD
+    )
+    Optional<Assignment> findWithAllById(Long assignmentId);
 
     @Modifying(clearAutomatically = true)
     @Query("update Assignment a set a.viewCount = a.viewCount + 1 where a.id = :assignmentId")

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/service/AssignmentService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/service/AssignmentService.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface AssignmentService {
     Long createAssignment(AssignmentCreationRequestDto assignmentCreationRequestDto, Long userId);
-    AssignmentDetailResponseDto getAssignment(Long assignmentId);
+    AssignmentDetailResponseDto getAssignment(Long viewerId, Long assignmentId);
     Page<AssignmentSummaryResponseDto> getAssignmentSummaries(AssignmentSearchCondition condition, Pageable pageable);
     void updateAssignment(Long userId, Long assignmentId, AssignmentUpdateRequestDto updateDto);
     void deleteAssignment(Long userId, Long assignmentId);

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
@@ -51,14 +51,27 @@ public class AssignmentServiceImpl implements AssignmentService {
 
     @Transactional
     @Override
-    public AssignmentDetailResponseDto getAssignment(Long assignmentId) {
-        int updated = assignmentRepository.increaseViewCount(assignmentId);
-        if (updated == 0) {
+    public AssignmentDetailResponseDto getAssignment(Long viewerId, Long assignmentId) {
+        Assignment assignment = assignmentRepository.findWithAllById(assignmentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ASSIGNMENT_NOT_FOUND));
+
+        // 삭제 여부 확인
+        if (assignment.getStatus() == RecruitmentStatus.CANCELED) {
             throw new BusinessException(ErrorCode.ASSIGNMENT_NOT_FOUND);
         }
 
-        Assignment assignment = assignmentRepository.findById(assignmentId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ASSIGNMENT_NOT_FOUND));
+        User viewer = userService.findById(viewerId);
+
+        // 타 대학 공고를 조회하려는 경우
+        if (viewer.getUniversity() != assignment.getUser().getUniversity()) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_CROSS_UNIVERSITY_RECRUITMENT);
+        }
+
+        int updated = assignmentRepository.increaseViewCount(assignmentId);
+
+        if (updated == 0) {
+            throw new BusinessException(ErrorCode.ASSIGNMENT_NOT_FOUND);
+        }
 
         return AssignmentDetailResponseDto.fromEntity(assignment);
     }

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
@@ -39,7 +39,8 @@ public class ProjectController implements ProjectControllerDocs {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<APIResponse<Long>> createProject(
             @RequestBody @Valid ProjectCreationRequestDto requestDto,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
         Long projectId = projectService.createProject(userDetails.getUserId(), requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -48,8 +49,12 @@ public class ProjectController implements ProjectControllerDocs {
 
     @GetMapping("/{projectId}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<APIResponse<ProjectDetailResponseDto>> getProject(@PathVariable Long projectId) {
-        ProjectDetailResponseDto responseDto = projectService.getProject(projectId);
+    public ResponseEntity<APIResponse<ProjectDetailResponseDto>> getProject(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        ProjectDetailResponseDto responseDto =
+                projectService.getProject(userDetails.getUserId(), projectId);
 
         return ResponseEntity.ok(
                 APIResponse.ok("프로젝트 공고를 성공적으로 조회하였습니다.", responseDto)

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/docs/ProjectControllerDocs.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/docs/ProjectControllerDocs.java
@@ -205,10 +205,6 @@ public interface ProjectControllerDocs {
                                                                 "desc": "오프라인",
                                                                 "name": "OFFLINE"
                                                             },
-                                                            "period": {
-                                                                "startDate": "2025-12-25",
-                                                                "endDate": "2026-03-20"
-                                                            },
                                                             "positions": [
                                                                 {
                                                                     "position": {
@@ -244,8 +240,29 @@ public interface ProjectControllerDocs {
                                                             "grades": [
                                                                 2,
                                                                 3
-                                                            ]
+                                                            ],
+                                                            "period": {
+                                                                "startDate": "2025-12-25",
+                                                                "endDate": "2026-03-20"
+                                                            }
                                                         }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "**타 대학 공고인 경우**",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "FORBIDDEN_CROSS_UNIVERSITY_RECRUITMENT",
+                                                        "message": "타 대학의 공고입니다."
                                                     }
                                                     """
                                     )
@@ -270,7 +287,10 @@ public interface ProjectControllerDocs {
                     )
             )
     })
-    ResponseEntity<APIResponse<ProjectDetailResponseDto>> getProject(@PathVariable Long projectId);
+    ResponseEntity<APIResponse<ProjectDetailResponseDto>> getProject(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
 
     @Operation(
             summary = "프로젝트 공고 목록 조회(검색)",

--- a/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectDetailResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/dto/response/ProjectDetailResponseDto.java
@@ -15,43 +15,48 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProjectDetailResponseDto extends BaseRecruitmentDetailResponseDto {
     private final ProjectPurpose purpose;
     private final MeetingType meetingType;
-
-    @Setter
-    private Set<PositionInfoResponseDto> positions;
-
-    @Setter
-    private Set<Skill> skills;
-
-    @Setter
-    private Set<Integer> grades;
-
+    private final Set<PositionInfoResponseDto> positions;
+    private final Set<Skill> skills;
+    private final Set<Integer> grades;
     private final PeriodResponseDto period;
 
-    private ProjectDetailResponseDto(
-            Long id, Long authorId, String authorNickname, RecruitmentCategory category, University university,
-            String title, String content, LocalDateTime deadline, LocalDateTime createdAt,
-            RecruitmentStatus status, int viewCount, ProjectPurpose purpose, MeetingType meetingType, PeriodResponseDto period
+    public ProjectDetailResponseDto(
+            Long id, Long authorId, String authorNickname, RecruitmentCategory category,
+            University university, String title, String content, LocalDateTime deadline,
+            LocalDateTime createdAt, RecruitmentStatus status, int viewCount,
+            ProjectPurpose purpose, MeetingType meetingType, Set<PositionInfoResponseDto> positions,
+            Set<Skill> skills, Set<Integer> grades, PeriodResponseDto period
     ) {
         super(id, authorId, authorNickname, category, university, title, content, deadline, createdAt, status, viewCount);
         this.purpose = purpose;
         this.meetingType = meetingType;
+        this.positions = positions;
+        this.skills = skills;
+        this.grades = grades;
         this.period = period;
     }
 
     public static ProjectDetailResponseDto fromEntity(Project project) {
         User author = project.getUser();
         PeriodResponseDto period = PeriodResponseDto.from(project.getPeriod());
+        Set<Skill> skills = Set.copyOf(project.getSkills());
+        Set<Integer> grades = Set.copyOf(project.getGrades());
+        Set<PositionInfoResponseDto> positions = project.getPositions().stream()
+                .map(PositionInfoResponseDto::from)
+                .collect(Collectors.toUnmodifiableSet());
 
         return new ProjectDetailResponseDto(
-                project.getId(), author.getId(), author.getNickname(), project.getCategory(), author.getUniversity(),
-                project.getTitle(), project.getContent(), project.getDeadline(), project.getCreatedAt(),
-                project.getStatus(), project.getViewCount(), project.getPurpose(), project.getMeetingType(), period
+                project.getId(), author.getId(), author.getNickname(), project.getCategory(),
+                author.getUniversity(), project.getTitle(), project.getContent(), project.getDeadline(),
+                project.getCreatedAt(), project.getStatus(), project.getViewCount() + 1,
+                project.getPurpose(), project.getMeetingType(), positions, skills, grades, period
         );
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
@@ -1,8 +1,7 @@
 package com.wagglex2.waggle.domain.project.repository;
 
-import com.wagglex2.waggle.domain.common.type.PositionParticipantInfo;
-import com.wagglex2.waggle.domain.common.type.Skill;
 import com.wagglex2.waggle.domain.project.entity.Project;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,26 +9,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
-import java.util.Set;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
 
-    // 1. Project + User
-    @Query("SELECT p FROM Project p JOIN FETCH p.user u WHERE p.id = :id")
-    Optional<Project> findByIdWithUser(@Param("id") Long id);
-
-    // 2. Positions
-    @Query("SELECT pos FROM Project p JOIN p.positions pos WHERE p.id = :id")
-    Set<PositionParticipantInfo> findPositionsByProjectId(@Param("id") Long id);
-
-    // 3. Skills
-    @Query("SELECT s FROM Project p JOIN p.skills s WHERE p.id = :id")
-    Set<Skill> findSkillsByProjectId(@Param("id") Long id);
-
-    // 4. Grades
-    @Query("SELECT g FROM Project p JOIN p.grades g WHERE p.id = :id")
-    Set<Integer> findGradesByProjectId(@Param("id") Long id);
+    @EntityGraph(
+            attributePaths = {"user", "positions", "skills", "grades"},
+            type = EntityGraph.EntityGraphType.LOAD
+    )
+    Optional<Project> findWithAllById(Long id);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Project p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public interface ProjectService {
     Long createProject(Long userId, ProjectCreationRequestDto projectCreationRequestDto);
-    ProjectDetailResponseDto getProject(Long projectId);
+    ProjectDetailResponseDto getProject(Long viewerId, Long projectId);
     Page<ProjectSummaryResponseDto> getProjectSummaries(ProjectSearchCondition condition, Pageable pageable);
     List<ProjectSummaryResponseDto> getProjectSummariesByIds(List<Long> projectIds);
     void updateProject(Long userId, Long projectId, ProjectUpdateRequestDto updateDto);

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -2,9 +2,7 @@ package com.wagglex2.waggle.domain.project.service.serviceImpl;
 
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
-import com.wagglex2.waggle.domain.common.dto.response.PositionInfoResponseDto;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
-import com.wagglex2.waggle.domain.common.type.Skill;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectCreationRequestDto;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectSearchCondition;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectUpdateRequestDto;
@@ -17,7 +15,6 @@ import com.wagglex2.waggle.domain.team.entity.Team;
 import com.wagglex2.waggle.domain.team.service.TeamService;
 import com.wagglex2.waggle.domain.team_member.entity.TeamMember;
 import com.wagglex2.waggle.domain.team_member.entity.type.TeamRole;
-import com.wagglex2.waggle.domain.team_member.service.TeamMemberService;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -29,8 +26,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -59,35 +54,29 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Transactional
     @Override
-    public ProjectDetailResponseDto getProject(Long projectId) {
+    public ProjectDetailResponseDto getProject(Long viewerId, Long projectId) {
+        Project project = projectRepository.findWithAllById(projectId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+
+        // 삭제 여부 확인
+        if (project.getStatus() == RecruitmentStatus.CANCELED) {
+            throw new BusinessException(ErrorCode.PROJECT_NOT_FOUND);
+        }
+
+        User viewer = userService.findById(viewerId);
+
+        // 타 대학 공고를 조회하려는 경우
+        if (viewer.getUniversity() != project.getUser().getUniversity()) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_CROSS_UNIVERSITY_RECRUITMENT);
+        }
+
         int updated = projectRepository.increaseViewCount(projectId);
 
         if (updated == 0) {
             throw new BusinessException(ErrorCode.PROJECT_NOT_FOUND);
         }
 
-        // 각 collection 정보는 추가 쿼리로 조회 후 dto에 추가
-        // Project 정보와 User 정보
-        ProjectDetailResponseDto responseDto = projectRepository.findByIdWithUser(projectId)
-                .map(ProjectDetailResponseDto::fromEntity)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
-
-        // Position 정보
-        Set<PositionInfoResponseDto> positions = projectRepository.findPositionsByProjectId(projectId).stream()
-                .map(PositionInfoResponseDto::from)
-                .collect(Collectors.toSet());
-
-        // Skill 정보
-        Set<Skill> skills = projectRepository.findSkillsByProjectId(projectId);
-
-        // Grade 정보
-        Set<Integer> grades = projectRepository.findGradesByProjectId(projectId);
-
-        responseDto.setPositions(positions);
-        responseDto.setSkills(skills);
-        responseDto.setGrades(grades);
-
-        return responseDto;
+        return ProjectDetailResponseDto.fromEntity(project);
     }
 
     @Override

--- a/src/main/java/com/wagglex2/waggle/domain/study/controller/StudyController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/controller/StudyController.java
@@ -33,8 +33,11 @@ public class StudyController {
 
     @GetMapping("/{studyId}")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<APIResponse<StudyResponseDto>> getStudy(@PathVariable Long studyId) {
-        StudyResponseDto responseDto = studyService.getStudy(studyId);
+    public ResponseEntity<APIResponse<StudyResponseDto>> getStudy(
+            @PathVariable Long studyId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        StudyResponseDto responseDto = studyService.getStudy(userDetails.getUserId(), studyId);
 
         return ResponseEntity.ok(
                 APIResponse.ok("스터디 공고를 성공적으로 조회하였습니다.", responseDto)

--- a/src/main/java/com/wagglex2/waggle/domain/study/dto/response/StudyResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/dto/response/StudyResponseDto.java
@@ -11,7 +11,6 @@ import com.wagglex2.waggle.domain.study.entity.Study;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.entity.type.University;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.Set;
@@ -20,19 +19,18 @@ import java.util.Set;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StudyResponseDto extends BaseRecruitmentDetailResponseDto {
     private final ParticipantInfoResponseDto participants;
+    private final Set<Skill> skills;
     private final PeriodResponseDto period;
 
-    @Setter
-    private Set<Skill> skills;
-
     private StudyResponseDto(
-            Long id, Long authorId, String authorNickname, RecruitmentCategory category, University university,
-            String title, String content, LocalDateTime deadline, LocalDateTime createdAt,
-            RecruitmentStatus status, int viewCount,
-            ParticipantInfoResponseDto participants, PeriodResponseDto period
+            Long id, Long authorId, String authorNickname, RecruitmentCategory category,
+            University university, String title, String content, LocalDateTime deadline,
+            LocalDateTime createdAt, RecruitmentStatus status, int viewCount,
+            ParticipantInfoResponseDto participants, Set<Skill> skills, PeriodResponseDto period
     ) {
         super(id, authorId, authorNickname, category, university, title, content, deadline, createdAt, status, viewCount);
         this.participants = participants;
+        this.skills = skills;
         this.period = period;
     }
 
@@ -40,12 +38,12 @@ public class StudyResponseDto extends BaseRecruitmentDetailResponseDto {
         User author = study.getUser();
         ParticipantInfoResponseDto participants = ParticipantInfoResponseDto.from(study.getParticipants());
         PeriodResponseDto period = PeriodResponseDto.from(study.getPeriod());
-
+        Set<Skill> skills = Set.copyOf(study.getSkills());
 
         return new StudyResponseDto(
                 study.getId(), author.getId(), author.getNickname(), study.getCategory(), author.getUniversity(),
                 study.getTitle(), study.getContent(), study.getDeadline(), study.getCreatedAt(),
-                study.getStatus(), study.getViewCount(), participants, period
+                study.getStatus(), study.getViewCount() + 1, participants, skills, period
         );
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/repository/StudyRepository.java
@@ -1,14 +1,24 @@
 package com.wagglex2.waggle.domain.study.repository;
 
 import com.wagglex2.waggle.domain.study.entity.Study;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StudyRepository extends JpaRepository<Study, Long> {
+
+    @EntityGraph(
+            attributePaths = {"user", "skills"},
+            type = EntityGraph.EntityGraphType.LOAD
+    )
+    Optional<Study> findWithAllById(Long studyId);
+
     @Modifying(clearAutomatically = true)
     @Query("update Study a set a.viewCount = a.viewCount + 1 where a.id = :studyId")
     int increaseViewCount(@Param("studyId") Long studyId);

--- a/src/main/java/com/wagglex2/waggle/domain/study/service/StudyService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/service/StudyService.java
@@ -5,5 +5,5 @@ import com.wagglex2.waggle.domain.study.dto.response.StudyResponseDto;
 
 public interface StudyService {
     Long createStudy(StudyCreationRequestDto studyCreationRequestDto, Long userId);
-    StudyResponseDto getStudy(Long studyId);
+    StudyResponseDto getStudy(Long viewerId, Long studyId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/study/service/serviceImpl/StudyServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/service/serviceImpl/StudyServiceImpl.java
@@ -2,6 +2,7 @@ package com.wagglex2.waggle.domain.study.service.serviceImpl;
 
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
+import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.study.dto.request.StudyCreationRequestDto;
 import com.wagglex2.waggle.domain.study.dto.response.StudyResponseDto;
 import com.wagglex2.waggle.domain.study.entity.Study;
@@ -31,14 +32,27 @@ public class StudyServiceImpl implements StudyService {
 
     @Transactional
     @Override
-    public StudyResponseDto getStudy(Long studyId) {
-        int updated = studyRepository.increaseViewCount(studyId);
-        if (updated == 0) {
+    public StudyResponseDto getStudy(Long viewerId, Long studyId) {
+        Study study = studyRepository.findWithAllById(studyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
+
+        // 삭제 여부 확인
+        if (study.getStatus() == RecruitmentStatus.CANCELED) {
             throw new BusinessException(ErrorCode.STUDY_NOT_FOUND);
         }
 
-        Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.STUDY_NOT_FOUND));
+        User viewer = userService.findById(viewerId);
+
+        // 타 대학 공고를 조회하려는 경우
+        if (viewer.getUniversity() != study.getUser().getUniversity()) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_CROSS_UNIVERSITY_RECRUITMENT);
+        }
+
+        int updated = studyRepository.increaseViewCount(studyId);
+
+        if (updated == 0) {
+            throw new BusinessException(ErrorCode.STUDY_NOT_FOUND);
+        }
 
         return StudyResponseDto.fromEntity(study);
     }

--- a/src/test/java/com/wagglex2/waggle/domain/assignment/controller/AssignmentControllerTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/assignment/controller/AssignmentControllerTest.java
@@ -5,10 +5,7 @@ import com.wagglex2.waggle.common.security.jwt.JwtUtil;
 import com.wagglex2.waggle.domain.assignment.dto.response.AssignmentDetailResponseDto;
 import com.wagglex2.waggle.domain.assignment.entity.Assignment;
 import com.wagglex2.waggle.domain.assignment.service.AssignmentService;
-import com.wagglex2.waggle.domain.common.dto.response.ParticipantInfoResponseDto;
 import com.wagglex2.waggle.domain.common.type.ParticipantInfo;
-import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
-import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.entity.type.University;
 import com.wagglex2.waggle.domain.user.service.UserService;
@@ -59,7 +56,7 @@ class AssignmentControllerTest {
         // given
         Assignment assignment = createAssignment();
         AssignmentDetailResponseDto responseDto = AssignmentDetailResponseDto.fromEntity(assignment);
-        given(assignmentService.getAssignment(1L)).willReturn(responseDto);
+        given(assignmentService.getAssignment(1L, 1L)).willReturn(responseDto);
 
         // when
         String responseJson = mockMvc.perform(

--- a/src/test/java/com/wagglex2/waggle/domain/assignment/service/AssignmentServiceImplTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/assignment/service/AssignmentServiceImplTest.java
@@ -4,10 +4,7 @@ import com.wagglex2.waggle.domain.assignment.dto.response.AssignmentDetailRespon
 import com.wagglex2.waggle.domain.assignment.entity.Assignment;
 import com.wagglex2.waggle.domain.assignment.repository.AssignmentRepository;
 import com.wagglex2.waggle.domain.assignment.service.serviceImpl.AssignmentServiceImpl;
-import com.wagglex2.waggle.domain.common.dto.response.ParticipantInfoResponseDto;
 import com.wagglex2.waggle.domain.common.type.ParticipantInfo;
-import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
-import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.entity.type.University;
 import org.junit.jupiter.api.DisplayName;
@@ -43,7 +40,7 @@ class AssignmentServiceImplTest {
         given(assignmentRepository.increaseViewCount(1L)).willReturn(1);
 
         // when
-        AssignmentDetailResponseDto actual = assignmentService.getAssignment(1L);
+        AssignmentDetailResponseDto actual = assignmentService.getAssignment(1L, 1L);
 
         // then
         AssignmentDetailResponseDto expected = AssignmentDetailResponseDto.fromEntity(assignment);

--- a/src/test/java/com/wagglex2/waggle/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/controller/ProjectControllerTest.java
@@ -9,6 +9,7 @@ import com.wagglex2.waggle.domain.project.service.ProjectService;
 import com.wagglex2.waggle.domain.project.type.MeetingType;
 import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
 import com.wagglex2.waggle.domain.user.entity.User;
+import com.wagglex2.waggle.domain.user.entity.type.University;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,7 +64,7 @@ class ProjectControllerTest {
         // given
         Project project = createProject();
         ProjectDetailResponseDto responseDto = ProjectDetailResponseDto.fromEntity(project);
-        given(projectService.getProject(1L)).willReturn(responseDto);
+        given(projectService.getProject(1L, 1L)).willReturn(responseDto);
 
         // when
         String responseJson = mockMvc.perform(

--- a/src/test/java/com/wagglex2/waggle/domain/project/service/ProjectServiceImplTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/project/service/ProjectServiceImplTest.java
@@ -40,30 +40,18 @@ class ProjectServiceImplTest {
     void getProject() {
         // given
         Project project = createProject();
-        given(projectRepository.findByIdWithUser(1L)).willReturn(Optional.of(project));
-        given(projectRepository.findPositionsByProjectId(1L)).willReturn(project.getPositions());
-        given(projectRepository.findSkillsByProjectId(1L)).willReturn(project.getSkills());
-        given(projectRepository.findGradesByProjectId(1L)).willReturn(project.getGrades());
         given(projectRepository.increaseViewCount(1L)).willReturn(1);
 
         // when
-        ProjectDetailResponseDto actual = projectService.getProject(1L);
+        ProjectDetailResponseDto actual = projectService.getProject(1L, 1L);
 
         // then
         ProjectDetailResponseDto expected = ProjectDetailResponseDto.fromEntity(project);
-        expected.setPositions(project.getPositions().stream()
-                .map(PositionInfoResponseDto::from).collect(Collectors.toSet()));
-        expected.setSkills(project.getSkills());
-        expected.setGrades(project.getGrades());
 
         assertThat(actual).usingRecursiveComparison()
                 .ignoringFields("viewCount")
                 .isEqualTo(expected);
 
-        verify(projectRepository, times(1)).findByIdWithUser(1L);
-        verify(projectRepository, times(1)).findPositionsByProjectId(1L);
-        verify(projectRepository, times(1)).findSkillsByProjectId(1L);
-        verify(projectRepository, times(1)).findGradesByProjectId(1L);
         verify(projectRepository, times(1)).increaseViewCount(1L);
     }
 

--- a/src/test/java/com/wagglex2/waggle/domain/study/controller/StudyControllerTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/study/controller/StudyControllerTest.java
@@ -56,7 +56,7 @@ class StudyControllerTest {
         // given
         Study study = createStudy();
         StudyResponseDto responseDto = StudyResponseDto.fromEntity(study);
-        given(studyService.getStudy(1L)).willReturn(responseDto);
+        given(studyService.getStudy(1L, 1L)).willReturn(responseDto);
 
         // when
         String responseJson = mockMvc.perform(

--- a/src/test/java/com/wagglex2/waggle/domain/study/service/StudyServiceImplTest.java
+++ b/src/test/java/com/wagglex2/waggle/domain/study/service/StudyServiceImplTest.java
@@ -42,7 +42,7 @@ class StudyServiceImplTest {
         given(studyRepository.increaseViewCount(1L)).willReturn(1);
 
         // when
-        StudyResponseDto actual = studyService.getStudy(1L);
+        StudyResponseDto actual = studyService.getStudy(1L, 1L);
 
         // then
         StudyResponseDto expected = StudyResponseDto.fromEntity(study);


### PR DESCRIPTION
(#63) 기반

기존의 코드에서는 `삭제 처리된 공고`와 `타 대학 공고` 모두 조회가 되는 문제가 있음.

이 PR은 관련 조건을 추가하여 문제 해결

---

- 조건 검사를 위해 각 공고 엔티티 `@EntityGraph`로 즉시 로딩
- 컬렉션 조회 방식 변경 (refactor)
    - 목적: 쿼리 수를 줄이기 위함
    - 변경 전: 각 컬렉션을 각각 Fetch Join
    - 변경 후: `@EntityGraph`로 한 번에 조회
- `fromEntity(...)` 내부에서 `ResponseDto` 생성자에 `viewCount + 1` 전달
    - 코드 변경으로 조회수 쿼리 전에 엔티티를 조회하기 때문
- `ProjectControllerDocs`에 관련 응답 형식 추가