### PR TITLE
fix: 프로젝트 및 과제 목록 조회 쿼리 보완

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/assignment/controller/AssignmentController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/controller/AssignmentController.java
@@ -62,7 +62,8 @@ public class AssignmentController {
             @RequestParam(value = "q", required = false) String keywords,
             @RequestParam(value = "grades", required = false) Set<Integer> grades,
             @RequestParam(value = "status", required = false) RecruitmentStatus status,
-            @PageableDefault(size = 9) Pageable pageable
+            @PageableDefault(size = 9) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Set<String> nouns = (keywords != null) ? KomoranUtil.getNouns(keywords) : Set.of();
         Set<Integer> gradeSet = (grades != null) ? Set.copyOf(grades) : Set.of();
@@ -74,7 +75,7 @@ public class AssignmentController {
         );
 
         Page<AssignmentSummaryResponseDto> assignmentSummaries =
-                assignmentService.getAssignmentSummaries(condition, pageable);
+                assignmentService.getAssignmentSummaries(userDetails.getUserId(), condition, pageable);
 
         return ResponseEntity.ok(
                 APIResponse.ok("과제 공고 목록을 성공적으로 조회하였습니다.", assignmentSummaries)

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepositoryCustom.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepositoryCustom.java
@@ -18,7 +18,7 @@ public interface AssignmentRepositoryCustom {
      * @param pageable  페이징 및 정렬 정보 ({@link org.springframework.data.domain.Pageable})
      * @return 조건에 맞는 과제 요약 DTO 페이지 ({@link org.springframework.data.domain.Page}&lt;{@link AssignmentSummaryResponseDto}&gt;)
      */
-    Page<AssignmentSummaryResponseDto> getAssignmentSummaries(AssignmentSearchCondition condition, Pageable pageable);
+    Page<AssignmentSummaryResponseDto> getAssignmentSummaries(Long viewerId, AssignmentSearchCondition condition, Pageable pageable);
 
     /**
      * 주어진 Assignment ID 목록에 해당하는 과제 요약 정보를 조회한다.

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepositoryImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentSearchCondition;
 import com.wagglex2.waggle.domain.assignment.dto.response.AssignmentSummaryResponseDto;
+import com.wagglex2.waggle.domain.common.querydsl.RecruitmentSearchMatcher;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -106,11 +107,6 @@ public class AssignmentRepositoryImpl implements AssignmentRepositoryCustom {
                                 assignment.department,
                                 assignment.lecture,
                                 assignment.lectureCode,
-                                Projections.constructor(
-                                        com.wagglex2.waggle.domain.common.dto.response.ParticipantInfoResponseDto.class,
-                                        assignment.participants.currParticipants,
-                                        assignment.participants.maxParticipants
-                                ),
                                 set(assignment.grades.any())
                         ))
                 );
@@ -133,15 +129,12 @@ public class AssignmentRepositoryImpl implements AssignmentRepositoryCustom {
     /**
      * 제목(title) 또는 내용(content)에 키워드 중 하나라도 포함되는 조건 생성
      */
-    private BooleanBuilder containsAnyKeyword(Set<String> keywords) {
-        if (keywords == null || keywords.isEmpty())
-            return null;
-        BooleanBuilder builder = new BooleanBuilder();
-        keywords.forEach(keyword ->
-                builder.or(assignment.title.containsIgnoreCase(keyword))
-                        .or(assignment.content.containsIgnoreCase(keyword))
+    private BooleanExpression containsAnyKeyword(Set<String> keywords) {
+        return RecruitmentSearchMatcher.match(
+                keywords,
+                assignment.title,
+                assignment.content
         );
-        return builder;
     }
 
     /**

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepositoryImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.wagglex2.waggle.domain.assignment.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentSearchCondition;
@@ -41,11 +42,17 @@ public class AssignmentRepositoryImpl implements AssignmentRepositoryCustom {
      *     </ol>
      */
     @Override
-    public Page<AssignmentSummaryResponseDto> getAssignmentSummaries(AssignmentSearchCondition condition, Pageable pageable) {
+    public Page<AssignmentSummaryResponseDto> getAssignmentSummaries(Long viewerId, AssignmentSearchCondition condition, Pageable pageable) {
         BooleanBuilder where = new BooleanBuilder()
                 .and(eqStatus(condition.status()))
                 .and(containsAnyKeyword(condition.keywords()))
-                .and(containsAnyGrade(condition.grades()));
+                .and(containsAnyGrade(condition.grades()))
+                .and(assignment.user.university.eq(  // 같은 대학의 공고만을 조회
+                        JPAExpressions
+                                .select(user.university)
+                                .from(user)
+                                .where(user.id.eq(viewerId))
+                ));
 
         // 조건 에 맞는 모든 Assignment 공고 id 조회
         List<Long> assignmentIds = queryFactory
@@ -119,7 +126,7 @@ public class AssignmentRepositoryImpl implements AssignmentRepositoryCustom {
      */
     private BooleanExpression eqStatus(RecruitmentStatus status) {
         if (status == null || status == RecruitmentStatus.CANCELED)
-            return null;
+            return assignment.status.ne(RecruitmentStatus.CANCELED);
         return assignment.status.eq(status);
     }
 

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/service/AssignmentService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/service/AssignmentService.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 public interface AssignmentService {
     Long createAssignment(AssignmentCreationRequestDto assignmentCreationRequestDto, Long userId);
     AssignmentDetailResponseDto getAssignment(Long viewerId, Long assignmentId);
-    Page<AssignmentSummaryResponseDto> getAssignmentSummaries(AssignmentSearchCondition condition, Pageable pageable);
+    Page<AssignmentSummaryResponseDto> getAssignmentSummaries(Long viewerId, AssignmentSearchCondition condition, Pageable pageable);
     void updateAssignment(Long userId, Long assignmentId, AssignmentUpdateRequestDto updateDto);
     void deleteAssignment(Long userId, Long assignmentId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
@@ -78,10 +78,11 @@ public class AssignmentServiceImpl implements AssignmentService {
 
     @Override
     public Page<AssignmentSummaryResponseDto> getAssignmentSummaries(
+            Long viewerId,
             AssignmentSearchCondition condition,
             Pageable pageable
     ) {
-        return assignmentRepository.getAssignmentSummaries(condition, pageable);
+        return assignmentRepository.getAssignmentSummaries(viewerId, condition, pageable);
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/common/querydsl/MatchFunctionContributor.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/querydsl/MatchFunctionContributor.java
@@ -1,0 +1,56 @@
+package com.wagglex2.waggle.domain.common.querydsl;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.StandardBasicTypes;
+
+/**
+ * MySQL FULLTEXT 검색을 위해 {@code MATCH...AGAINST} 쿼리를 Hibernate에 등록하는 클래스다.
+ *
+ * <p>이 클래스는 Hibernate의 FunctionRegistry에 "MATCH_AGAINST"라는 이름으로
+ * 커스텀 함수를 등록한다.
+ *
+ * <p>등록되는 패턴은 2개의 컬럼(공고 제목, 본문)과 1개의 검색어를 지원한다:
+ * <pre>
+ * {@code MATCH (?1, ?2) AGAINST (?3 IN BOOLEAN MODE)}
+ * </pre>
+ *
+ * <p>사용 예시 (QueryDSL):
+ * <pre>{@code
+ * // 두 컬럼과 검색어를 이용한 FULLTEXT 검색 조건 생성
+ * Expressions.numberTemplate(
+ *      Double.class,
+ *      "FUNCTION('MATCH_AGAINST', {0}, {1}, {2})",
+ *      col1, col2, keyword
+ * ).gt(0);
+ * }</pre>
+ *
+ * @see RecruitmentSearchMatcher
+ */
+public class MatchFunctionContributor implements FunctionContributor {
+
+    /**
+     * 등록할 커스텀 함수의 이름
+     */
+    private static final String FUNCTION_NAME = "MATCH_AGAINST";
+
+    /**
+     * MATCH_AGAINST 함수의 SQL 패턴 (컬럼 2개 + 검색어 1개)
+     */
+    private static final String FUNCTION_PATTERN = "MATCH (?1, ?2) AGAINST (?3 IN BOOLEAN MODE)";
+
+    /**
+     * MATCH_AGAINST 함수를 등록
+     */
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions.getFunctionRegistry()
+                .registerPattern(
+                        FUNCTION_NAME,
+                        FUNCTION_PATTERN,
+                        functionContributions.getTypeConfiguration()
+                                .getBasicTypeRegistry()
+                                .resolve(StandardBasicTypes.DOUBLE)
+                );
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/common/querydsl/RecruitmentSearchMatcher.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/querydsl/RecruitmentSearchMatcher.java
@@ -1,0 +1,67 @@
+package com.wagglex2.waggle.domain.common.querydsl;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
+
+import java.util.Set;
+
+/**
+ * 공고 검색용 FULLTEXT MATCH 헬퍼 클래스다.
+ *
+ * <p>MySQL의 MATCH...AGAINST 쿼리를 사용하여 제목(title)과 내용(content)에서
+ * 키워드를 검색하는 QueryDSL 조건을 생성한다.
+ *
+ * <p>사용 예시:
+ * <pre>{@code
+ * BooleanExpression condition = RecruitmentSearchMatcher.match(
+ *      Set.of("스프링", "부트"),
+ *      project.title,
+ *      project.content
+ * );
+ * queryFactory.selectFrom(project)
+ *             .where(condition)
+ *             .fetch();
+ * }</pre>
+ *
+ * @see MatchFunctionContributor
+ */
+public class RecruitmentSearchMatcher {
+
+    /**
+     * 제목(title)과 내용(content)에서 주어진 키워드가 포함된 행을 찾는
+     * BooleanExpression을 생성한다.
+     *
+     * <p>키워드가 비어 있거나 null인 경우 null을 반환한다.
+     *
+     * @param keywords 검색할 키워드
+     * @param title 검색 대상 제목 컬럼
+     * @param content 검색 대상 내용 컬럼
+     * @return 키워드가 포함된 행을 찾는 BooleanExpression, 키워드가 없으면 null을 반환
+     */
+    public static BooleanExpression match(Set<String> keywords, StringPath title, StringPath content) {
+        if (keywords == null || keywords.isEmpty()) {
+            return null;
+        }
+
+        /*
+          FULLTEXT 조건 생성
+
+          - 예시: "사과* 바나나*"
+          - 의미: "사과" 또는 "바나나"가 포함되는 열을 찾되,
+                  조사나 접미사 등이 붙은 경우도 허용 ("사과는", "바나나가")
+        */
+        StringBuilder sb = new StringBuilder();
+        keywords.forEach(keyword -> sb.append(keyword).append("* "));
+
+        String fullTextCondition = sb.toString().trim();
+
+        // Boolean Mode FULLTEXT 검색
+        // 제목(title) 또는 내용(content)에 키워드 중 하나라도 포함되는 행을 찾는다.
+        return Expressions.numberTemplate(
+                Double.class,
+                "FUNCTION('MATCH_AGAINST', {0}, {1}, {2})",
+                title, content, fullTextCondition
+        ).gt(0);
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
@@ -69,7 +69,8 @@ public class ProjectController implements ProjectControllerDocs {
             @RequestParam(value = "positions", required = false) List<PositionType> positions,
             @RequestParam(value = "skills", required = false) List<Skill> skills,
             @RequestParam(value = "status", required = false) RecruitmentStatus status,
-            @PageableDefault(size = 9) Pageable pageable
+            @PageableDefault(size = 9) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Set<String> nouns = (keywords != null) ? komoranUtil.getNouns(keywords) : Set.of();
         Set<PositionType> positionSet = (positions != null) ? Set.copyOf(positions) : Set.of();
@@ -84,7 +85,7 @@ public class ProjectController implements ProjectControllerDocs {
         );
 
         Page<ProjectSummaryResponseDto> projectSummaries =
-                projectService.getProjectSummaries(condition, pageable);
+                projectService.getProjectSummaries(userDetails.getUserId(), condition, pageable);
 
         return ResponseEntity.ok(
                 APIResponse.ok("프로젝트 공고 목록을 성공적으로 조회하였습니다.", projectSummaries)

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/docs/ProjectControllerDocs.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/docs/ProjectControllerDocs.java
@@ -575,7 +575,8 @@ public interface ProjectControllerDocs {
             @RequestParam(value = "positions", required = false) List<PositionType> positions,
             @RequestParam(value = "skills", required = false) List<Skill> skills,
             @RequestParam(value = "status", required = false) RecruitmentStatus status,
-            @PageableDefault(size = 9) Pageable pageable
+            @PageableDefault(size = 9) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
     @Operation(

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryCustom.java
@@ -18,7 +18,7 @@ public interface ProjectRepositoryCustom {
      * @param pageable  페이징 및 정렬 정보 ({@link org.springframework.data.domain.Pageable})
      * @return 조건에 맞는 프로젝트 요약 DTO 페이지 ({@link org.springframework.data.domain.Page}&lt;{@link ProjectSummaryResponseDto}&gt;)
      */
-    Page<ProjectSummaryResponseDto> getProjectSummaries(ProjectSearchCondition condition, Pageable pageable);
+    Page<ProjectSummaryResponseDto> getProjectSummaries(Long viewerId, ProjectSearchCondition condition, Pageable pageable);
 
     /**
      * 주어진 Project ID 목록에 해당하는 프로젝트 요약 정보를 조회한다.

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.wagglex2.waggle.domain.project.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wagglex2.waggle.domain.common.type.*;
@@ -42,14 +43,20 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
      *     </ol>
      */
     @Override
-    public Page<ProjectSummaryResponseDto> getProjectSummaries(ProjectSearchCondition condition, Pageable pageable) {
+    public Page<ProjectSummaryResponseDto> getProjectSummaries(Long viewerId, ProjectSearchCondition condition, Pageable pageable) {
         // where문 조건
         BooleanBuilder builder = new BooleanBuilder()
                 .and(eqPurpose(condition.purpose()))
                 .and(eqStatus(condition.status()))
                 .and(containsAnyKeyword(condition.keywords()))
                 .and(containsAnyPosition(condition.positions()))
-                .and(containsAnySkill(condition.skills()));
+                .and(containsAnySkill(condition.skills()))
+                .and(project.user.university.eq(  // 같은 대학의 공고만을 조회
+                        JPAExpressions
+                                .select(user.university)
+                                .from(user)
+                                .where(user.id.eq(viewerId))
+                ));
 
         // 조건에 맞는 모든 Project 공고 id 조회
         List<Long> projectIds = queryFactory
@@ -130,7 +137,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
      */
     private BooleanExpression eqStatus(RecruitmentStatus status) {
         if (status == null || status == RecruitmentStatus.CANCELED) {
-            return null;
+            return project.status.ne(RecruitmentStatus.CANCELED);
         }
 
         return project.status.eq(status);

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wagglex2.waggle.domain.common.querydsl.RecruitmentSearchMatcher;
 import com.wagglex2.waggle.domain.common.type.*;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectSearchCondition;
 import com.wagglex2.waggle.domain.project.dto.response.ProjectSummaryResponseDto;
@@ -146,19 +147,12 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     /**
      * 제목(title) 또는 내용(content)에 키워드 중 하나라도 포함되는 조건 생성
      */
-    private BooleanBuilder containsAnyKeyword(Set<String> keywords) {
-        if (keywords == null || keywords.isEmpty()) {
-            return null;
-        }
-
-        BooleanBuilder builder = new BooleanBuilder();
-        keywords.forEach(keyword ->
-                builder
-                        .or(project.title.containsIgnoreCase(keyword))
-                        .or(project.content.containsIgnoreCase(keyword))
+    private BooleanExpression containsAnyKeyword(Set<String> keywords) {
+        return RecruitmentSearchMatcher.match(
+                keywords,
+                project.title,
+                project.content
         );
-
-        return builder;
     }
 
     /**

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface ProjectService {
     Long createProject(Long userId, ProjectCreationRequestDto projectCreationRequestDto);
     ProjectDetailResponseDto getProject(Long viewerId, Long projectId);
-    Page<ProjectSummaryResponseDto> getProjectSummaries(ProjectSearchCondition condition, Pageable pageable);
+    Page<ProjectSummaryResponseDto> getProjectSummaries(Long viewerId, ProjectSearchCondition condition, Pageable pageable);
     List<ProjectSummaryResponseDto> getProjectSummariesByIds(List<Long> projectIds);
     void updateProject(Long userId, Long projectId, ProjectUpdateRequestDto updateDto);
     void deleteProject(Long userId, Long projectId);

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -81,10 +81,11 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public Page<ProjectSummaryResponseDto> getProjectSummaries(
+            Long viewerId,
             ProjectSearchCondition condition,
             Pageable pageable
     ) {
-        return projectRepository.getProjectSummaries(condition, pageable);
+        return projectRepository.getProjectSummaries(viewerId, condition, pageable);
     }
 
     /**

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.wagglex2.waggle.domain.common.querydsl.MatchFunctionContributor

--- a/src/main/resources/komoran/dic.user
+++ b/src/main/resources/komoran/dic.user
@@ -7,7 +7,12 @@
 프론트엔드	NNG
 백엔드	NNG
 풀스택	NNG
-C++	NNP
-c++	NNP
-C#	NNP
-c#	NNP
+네이버	NNP
+카카오	NNP
+라인	NNP
+쿠팡	NNP
+배달의 민족	NNP
+배달의민족	NNP
+배민	NNP
+당근	NNP
+토스	NNP


### PR DESCRIPTION
- 같은 학교의 공고만 조회되도록 쿼리 조건 추가
- 삭제된 공고가 조회되지 않도록 수정
- 검색어 매칭 로직 변경
    - 변경 전: `containsIgnoreCase()`를 통해 단순 포함 여부만 판단 + 기능이 제대로 동작하지 않았음
    - 변경 후: MySQL `FULLTEXT` 적용 -> 정확도 향상 (테이블에 FULLTEXT 인덱스 생성)
    - FULLTEXT를 hibernate에서 기본 제공하지 않기 때문에 이를 위한 관련 클래스 생성
- KOMORAN 사용자 정의 사전에 일부 기업명 추가