### PR TITLE
feat: 내 공고 조회 API 구현

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/application/dto/response/AppContentCommonResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/dto/response/AppContentCommonResponseDto.java
@@ -1,0 +1,44 @@
+package com.wagglex2.waggle.domain.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wagglex2.waggle.domain.project.type.MeetingType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공고 지원 응답의 공통 데이터를 담는 추상 DTO이다.
+ *
+ * <p><b>보유 필드:</b>
+ * <ul>
+ *     <li>{@link #applicationId} - 지원 ID</li>
+ *     <li>{@link #applicantId} - 지원자 ID</li>
+ *     <li>{@link #nickname} - 지원자 닉네임</li>
+ *     <li>{@link #meetingType} - 진행 방식</li>
+ *     <li>{@link #grade} - 지원자 학년</li>
+ *     <li>{@link #content} - 지원서 본문</li>
+ *     <li>{@link #appliedAt} - 지원 일자</li>
+ * </ul>
+ *
+ * @see AppContentProjectResponseDto
+ * @see AppContentSimpleResponseDto
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class AppContentCommonResponseDto {
+
+    private Long applicationId;
+    private Long applicantId;
+    private String nickname;
+    // TODO profile image
+    private final MeetingType meetingType;
+    private final Integer grade;
+    private final String content;
+
+    @JsonFormat(pattern = "yyyy.MM.dd")
+    private final LocalDateTime appliedAt;
+}

--- a/src/main/java/com/wagglex2/waggle/domain/application/dto/response/AppContentProjectResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/dto/response/AppContentProjectResponseDto.java
@@ -1,0 +1,52 @@
+package com.wagglex2.waggle.domain.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wagglex2.waggle.domain.common.type.PositionType;
+import com.wagglex2.waggle.domain.common.type.Skill;
+import com.wagglex2.waggle.domain.project.type.MeetingType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+/**
+ * 프로젝트 공고 지원 응답 DTO이다.
+ *
+ * <p>프로젝트 공고 전용 필드인 포지션과 기술 스택을 포함하며,
+ * {@link AppContentCommonResponseDto}를 상속한다.
+ *
+ * <p><b>보유 필드:</b>
+ * <ul>
+ *     <b>상위 클래스 필드</b>
+ *     <li>{@link #applicationId} - 지원 ID</li>
+ *     <li>{@link #applicantId} - 지원자 ID</li>
+ *     <li>{@link #nickname} - 지원자 닉네임</li>
+ *     <li>{@link #meetingType} - 진행 방식</li>
+ *     <li>{@link #grade} - 지원자 학년</li>
+ *     <li>{@link #content} - 지원서 본문</li>
+ *     <li>{@link #appliedAt} - 지원 일자</li>
+ *     <br>
+ *     <b>현재 클래스 필드</b>
+ *     <li>{@link #position} - 지원 포지션</li>
+ *     <li>{@link #skills} - 지원자 기술 스택</li>
+ * </ul>
+ *
+ * @see AppContentCommonResponseDto
+ */
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AppContentProjectResponseDto extends AppContentCommonResponseDto {
+
+    private final PositionType position;
+    private final Set<Skill> skills;
+
+    public AppContentProjectResponseDto(
+            Long applicationId, Long applicantId, String nickname,
+            MeetingType meetingType, Integer grade, String content,
+            LocalDateTime appliedAt, PositionType position, Set<Skill> skills
+    ) {
+        super(applicationId, applicantId, nickname, meetingType, grade, content, appliedAt);
+        this.position = position;
+        this.skills = skills;
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/application/dto/response/AppContentSimpleResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/dto/response/AppContentSimpleResponseDto.java
@@ -1,0 +1,39 @@
+package com.wagglex2.waggle.domain.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.wagglex2.waggle.domain.project.type.MeetingType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 과제 및 스터디 공고 지원 응답 DTO이다.
+ *
+ * <p>공통 필드만 포함하며, {@link AppContentCommonResponseDto}를 상속한다.
+ *
+ * <p><b>보유 필드:</b>
+ * <ul>
+ *     <b>상위 클래스 필드</b>
+ *     <li>{@link #applicationId} - 지원 ID</li>
+ *     <li>{@link #applicantId} - 지원자 ID</li>
+ *     <li>{@link #nickname} - 지원자 닉네임</li>
+ *     <li>{@link #meetingType} - 진행 방식</li>
+ *     <li>{@link #grade} - 지원자 학년</li>
+ *     <li>{@link #content} - 지원서 본문</li>
+ *     <li>{@link #appliedAt} - 지원 일자</li>
+ * </ul>
+ *
+ * @see AppContentCommonResponseDto
+ */
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AppContentSimpleResponseDto extends AppContentCommonResponseDto {
+
+    public AppContentSimpleResponseDto(
+            Long applicationId, Long applicantId, String nickname,
+            MeetingType meetingType, Integer grade, String content,
+            LocalDateTime appliedAt
+    ) {
+        super(applicationId, applicantId, nickname, meetingType, grade, content, appliedAt);
+    }
+}

--- a/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
@@ -8,8 +8,10 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -42,6 +44,28 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             RecruitmentCategory category,
             Pageable pageable
     );
+
+    /**
+     * 주어진 모집 공고 ID 목록에 해당하는 지원 정보를 조회한다.
+     * <p>
+     * 삭제되지 않고, {@code 대기중} 상태인 지원 정보를 조회하며, `createdAt` 기준 내림차순으로 정렬된다.
+     * </p>
+     *
+     * @param recruitmentIds 조회할 모집 공고 ID 목록
+     * @return 조건에 맞는 지원서 목록을 반환한다
+     */
+    @Query("""
+        SELECT a
+        FROM Application a
+        JOIN FETCH a.recruitment r
+        JOIN FETCH r.user
+        LEFT JOIN FETCH a.skills
+        WHERE r.id in :recruitmentIds
+        AND a.status = com.wagglex2.waggle.domain.application.type.ApplicationStatus.SUBMITTED
+        AND a.isDeleted = false
+        ORDER BY a.createdAt DESC
+    """)
+    List<Application> findAllByRecruitmentIds(@Param("recruitmentIds") List<Long> recruitmentIds);
 
     /**
      * 마감된 공고에 대한 모든 지원 상태를 CLOSED로 변경한다.

--- a/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
@@ -58,7 +58,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
         SELECT a
         FROM Application a
         JOIN FETCH a.recruitment r
-        JOIN FETCH r.user
+        JOIN FETCH a.applicant
         LEFT JOIN FETCH a.skills
         WHERE r.id in :recruitmentIds
         AND a.status = com.wagglex2.waggle.domain.application.type.ApplicationStatus.SUBMITTED

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/ApplicationService.java
@@ -7,10 +7,22 @@ import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ApplicationService {
 
     Long submitApplication(Long userId, Long recruitmentId, ApplicationCommonRequestDto requestDto);
     Application findById(Long id);
+
+    /**
+     * 주어진 모집 공고 ID 목록에 해당하는 제출된 지원서를 조회한다.
+     *
+     * <p>삭제되지 않은 지원서만 포함하며, 연관된 모집 공고와 작성자, 기술 스택을 함께 조회한다.</p>
+     *
+     * @param recruitmentId 조회할 모집 공고 ID 목록
+     * @return 조건에 맞는 지원서 목록을 반환한다
+     */
+    List<Application> findAllByRecruitmentIds(List<Long> recruitmentId);
     Page<ApplicationCommonResponseDto> getAllByUserIdAndRecruitmentCategory(Long userId, RecruitmentCategory category, Pageable pageable);
     void acceptApplication(Long deciderId, Long applicationId);
     void rejectApplication(Long deciderId, Long applicationId);

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -41,6 +41,8 @@ import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -110,6 +112,11 @@ public class ApplicationServiceImpl implements ApplicationService {
     public Application findById(Long id) {
         return applicationRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.APPLICATION_NOT_FOUND));
+    }
+
+    @Override
+    public List<Application> findAllByRecruitmentIds(List<Long> recruitmentIds) {
+        return applicationRepository.findAllByRecruitmentIds(recruitmentIds);
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/controller/AssignmentController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/controller/AssignmentController.java
@@ -2,6 +2,7 @@ package com.wagglex2.waggle.domain.assignment.controller;
 
 import com.wagglex2.waggle.common.response.APIResponse;
 import com.wagglex2.waggle.common.security.CustomUserDetails;
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.common.util.KomoranUtil;
 import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentCreationRequestDto;
 import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentSearchCondition;
@@ -13,7 +14,9 @@ import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -79,6 +82,25 @@ public class AssignmentController {
 
         return ResponseEntity.ok(
                 APIResponse.ok("과제 공고 목록을 성공적으로 조회하였습니다.", assignmentSummaries)
+        );
+    }
+
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<APIResponse<Page<RecruitmentWithAppsResponseDto>>> getMyAssignments(
+            @PageableDefault(size = 5) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        PageRequest pageRequest = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<RecruitmentWithAppsResponseDto> assignmentsWithApps = assignmentService.getAllByUserId(userDetails.getUserId(), pageRequest);
+
+        return ResponseEntity.ok(
+                APIResponse.ok("내 과제 공고 목록을 성공적으로 조회하였습니다.", assignmentsWithApps)
         );
     }
 

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/repository/AssignmentRepository.java
@@ -2,6 +2,8 @@ package com.wagglex2.waggle.domain.assignment.repository;
 
 import com.wagglex2.waggle.domain.assignment.entity.Assignment;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,6 +20,20 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long>, A
             type = EntityGraph.EntityGraphType.LOAD
     )
     Optional<Assignment> findWithAllById(Long assignmentId);
+
+    /**
+     * 특정 사용자가 작성한, 삭제되지 않은 과제 공고를 페이지 단위로 조회한다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param pageable 페이지네이션 정보
+     * @return 삭제되지 않은 과제 공고의 페이지(Page) 객체
+     */
+    @Query("""
+        Select a FROM Assignment a
+        WHERE a.user.id = :userId
+        AND a.status != com.wagglex2.waggle.domain.common.type.RecruitmentStatus.CANCELED
+    """)
+    Page<Assignment> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("update Assignment a set a.viewCount = a.viewCount + 1 where a.id = :assignmentId")

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/service/AssignmentService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/service/AssignmentService.java
@@ -5,6 +5,7 @@ import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentSearchConditi
 import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentUpdateRequestDto;
 import com.wagglex2.waggle.domain.assignment.dto.response.AssignmentDetailResponseDto;
 import com.wagglex2.waggle.domain.assignment.dto.response.AssignmentSummaryResponseDto;
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,6 +13,7 @@ public interface AssignmentService {
     Long createAssignment(AssignmentCreationRequestDto assignmentCreationRequestDto, Long userId);
     AssignmentDetailResponseDto getAssignment(Long viewerId, Long assignmentId);
     Page<AssignmentSummaryResponseDto> getAssignmentSummaries(Long viewerId, AssignmentSearchCondition condition, Pageable pageable);
+    Page<RecruitmentWithAppsResponseDto> getAllByUserId(Long userId, Pageable pageable);
     void updateAssignment(Long userId, Long assignmentId, AssignmentUpdateRequestDto updateDto);
     void deleteAssignment(Long userId, Long assignmentId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
@@ -2,6 +2,10 @@ package com.wagglex2.waggle.domain.assignment.service.serviceImpl;
 
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
+import com.wagglex2.waggle.common.validator.PageableValidator;
+import com.wagglex2.waggle.domain.application.dto.response.AppContentSimpleResponseDto;
+import com.wagglex2.waggle.domain.application.entity.Application;
+import com.wagglex2.waggle.domain.application.service.ApplicationService;
 import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentCreationRequestDto;
 import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentSearchCondition;
 import com.wagglex2.waggle.domain.assignment.dto.request.AssignmentUpdateRequestDto;
@@ -10,6 +14,7 @@ import com.wagglex2.waggle.domain.assignment.dto.response.AssignmentSummaryRespo
 import com.wagglex2.waggle.domain.assignment.entity.Assignment;
 import com.wagglex2.waggle.domain.assignment.repository.AssignmentRepository;
 import com.wagglex2.waggle.domain.assignment.service.AssignmentService;
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.team.entity.Team;
 import com.wagglex2.waggle.domain.team.service.TeamService;
@@ -19,19 +24,28 @@ import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AssignmentServiceImpl implements AssignmentService {
+    private static final Set<String> ASSIGNMENT_SORT_FIELDS = Set.of("createdAt");
     private final AssignmentRepository assignmentRepository;
     private final UserService userService;
     private final TeamService teamService;
+    private final ApplicationService applicationService;
+    private final PageableValidator pageableValidator;
 
     @Transactional
     @Override
@@ -83,6 +97,57 @@ public class AssignmentServiceImpl implements AssignmentService {
             Pageable pageable
     ) {
         return assignmentRepository.getAssignmentSummaries(viewerId, condition, pageable);
+    }
+
+    @PreAuthorize("#userId == authentication.principal.userId")
+    @Override
+    public Page<RecruitmentWithAppsResponseDto> getAllByUserId(
+            @P("userId") Long userId,
+            Pageable pageable
+    ) {
+        pageableValidator.validate(pageable);
+        pageableValidator.validateSort(pageable, ASSIGNMENT_SORT_FIELDS);
+
+        Page<Assignment> assignments = assignmentRepository.findAllByUserId(userId, pageable);
+
+        // 공고 ID 목록
+        List<Long> assignmnetIds = assignments.stream()
+                .map(Assignment::getId)
+                .toList();
+
+        // 공고 ID로 application 전체 조회
+        List<Application> applications = applicationService.findAllByRecruitmentIds(assignmnetIds);
+
+        // 공고 ID -> applications 매핑 Map 생성
+        Map<Long, List<Application>> appsByRecruitmentId = applications.stream()
+                .collect(Collectors.groupingBy(
+                        app -> app.getRecruitment().getId())
+                );
+
+        // DTO 조합
+        List<RecruitmentWithAppsResponseDto> content = assignments.stream()
+                .map(a -> new RecruitmentWithAppsResponseDto(
+                        a.getId(),
+                        a.getTitle(),
+                        a.getDeadline(),
+                        appsByRecruitmentId.getOrDefault(
+                                        a.getId(),
+                                        List.of()
+                                ).stream()
+                                .map(app -> new AppContentSimpleResponseDto(
+                                        app.getId(),
+                                        app.getApplicant().getId(),
+                                        app.getApplicant().getNickname(),
+                                        app.getMeetingType(),
+                                        app.getGrade(),
+                                        app.getContent(),
+                                        app.getCreatedAt()
+                                ))
+                                .toList()
+                ))
+                .toList();
+
+        return new PageImpl<>(content, pageable, assignments.getTotalElements());
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/common/dto/response/RecruitmentWithAppsResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/dto/response/RecruitmentWithAppsResponseDto.java
@@ -1,0 +1,20 @@
+package com.wagglex2.waggle.domain.common.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.wagglex2.waggle.domain.application.dto.response.AppContentCommonResponseDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 모집 공고와 해당 공고에 대한 지원 정보를 포함하는 DTO이다.
+ */
+public record RecruitmentWithAppsResponseDto(
+        Long recruitmentId,
+        String title,
+
+        @JsonFormat(pattern = "yyyy.MM.dd")
+        LocalDateTime deadline,
+
+        List<? extends AppContentCommonResponseDto> applications
+) { }

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/ProjectController.java
@@ -2,6 +2,7 @@ package com.wagglex2.waggle.domain.project.controller;
 
 import com.wagglex2.waggle.common.response.APIResponse;
 import com.wagglex2.waggle.common.security.CustomUserDetails;
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.common.type.PositionType;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.common.type.Skill;
@@ -17,7 +18,9 @@ import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -89,6 +92,25 @@ public class ProjectController implements ProjectControllerDocs {
 
         return ResponseEntity.ok(
                 APIResponse.ok("프로젝트 공고 목록을 성공적으로 조회하였습니다.", projectSummaries)
+        );
+    }
+
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<APIResponse<Page<RecruitmentWithAppsResponseDto>>> getMyProjects(
+            @PageableDefault(size = 5) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        PageRequest pageRequest = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<RecruitmentWithAppsResponseDto> projectsWithApps = projectService.getAllByUserId(userDetails.getUserId(), pageRequest);
+
+        return ResponseEntity.ok(
+                APIResponse.ok("내 프로젝트 공고 목록을 성공적으로 조회하였습니다.", projectsWithApps)
         );
     }
 

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/docs/ProjectControllerDocs.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/docs/ProjectControllerDocs.java
@@ -174,7 +174,7 @@ public interface ProjectControllerDocs {
                     description = "**프로젝트 공고 상세 조회 성공**",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = APIResponse.class),
+                            schema = @Schema(implementation = ProjectDetailResponseDto.class),
                             examples = {
                                     @ExampleObject(
                                             value = """
@@ -376,7 +376,9 @@ public interface ProjectControllerDocs {
                     description = "**프로젝트 공고 목록 조회 성공**",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = APIResponse.class),
+                            array = @ArraySchema(
+                                    schema = @Schema(implementation = ProjectSummaryResponseDto.class)
+                            ),
                             examples = {
                                     @ExampleObject(
                                             name = "/projects?page=4&size=3&purpose=contest",

--- a/src/main/java/com/wagglex2/waggle/domain/project/controller/docs/ProjectControllerDocs.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/controller/docs/ProjectControllerDocs.java
@@ -2,6 +2,7 @@ package com.wagglex2.waggle.domain.project.controller.docs;
 
 import com.wagglex2.waggle.common.response.APIResponse;
 import com.wagglex2.waggle.common.security.CustomUserDetails;
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.common.type.PositionType;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.common.type.Skill;
@@ -13,6 +14,7 @@ import com.wagglex2.waggle.domain.project.type.ProjectPurpose;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -576,6 +578,175 @@ public interface ProjectControllerDocs {
             @RequestParam(value = "skills", required = false) List<Skill> skills,
             @RequestParam(value = "status", required = false) RecruitmentStatus status,
             @PageableDefault(size = 9) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "내 프로젝트 공고 목록 조회",
+            description = """
+                    사용자별 등록한 프로젝트 공고 목록을 조회한다.<br>
+                    각 공고에 해당하는 지원 정보를 포함한다.<br>
+                    응답의 공고와 각 공고에 대한 지원 정보는 생성 일자, 지원 일자 기준 최신순이다.
+                    """,
+            security = @SecurityRequirement(name = "Bearer Token"),
+            parameters = {
+                    @Parameter(
+                            name = "page",
+                            description = """
+                                    **조회하려는 내 프로젝트 공고 목록 페이지**<br>
+                                    기본값: 0 (0부터 시작)
+                                    """,
+                            in = ParameterIn.QUERY
+                    ),
+                    @Parameter(
+                            name = "size",
+                            description = """
+                                    **조회하려는 내 프로젝트 공고 개수**<br>
+                                    기본값: 5
+                                    """,
+                            in = ParameterIn.QUERY
+                    )
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "**내 프로젝트 공고 목록 조회 성공**",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(
+                                    schema = @Schema(implementation = RecruitmentWithAppsResponseDto.class)
+                            ),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "SUCCESS",
+                                                        "message": "내 프로젝트 공고 목록을 성공적으로 조회하였습니다.",
+                                                        "data": {
+                                                            "content": [
+                                                                {
+                                                                    "recruitmentId": 141,
+                                                                    "title": "토스 주관 공모전 팀원 구합니다.",
+                                                                    "deadline": "2025.12.20",
+                                                                    "applications": []
+                                                                },
+                                                                {
+                                                                    "recruitmentId": 137,
+                                                                    "title": "네이버 주관 공모전 팀원 구합니다.",
+                                                                    "deadline": "2025.12.20",
+                                                                    "applications": [
+                                                                        {
+                                                                            "applicationId": 27,
+                                                                            "applicantId": 40,
+                                                                            "nickname": "박데통",
+                                                                            "meetingType": {
+                                                                                "desc": "온라인",
+                                                                                "name": "ONLINE"
+                                                                            },
+                                                                            "grade": 3,
+                                                                            "content": "이 프로젝트에 지원하고 싶습니다.",
+                                                                            "appliedAt": "2025.11.22",
+                                                                            "position": {
+                                                                                "desc": "프론트엔드",
+                                                                                "name": "FRONT_END"
+                                                                            },
+                                                                            "skills": [
+                                                                                {
+                                                                                    "desc": "JavaScript",
+                                                                                    "name": "JAVASCRIPT"
+                                                                                },
+                                                                                {
+                                                                                    "desc": "React",
+                                                                                    "name": "REACT"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "applicationId": 12,
+                                                                            "applicantId": 34,
+                                                                            "nickname": "매운새우깡",
+                                                                            "meetingType": {
+                                                                                "desc": "온라인",
+                                                                                "name": "ONLINE"
+                                                                            },
+                                                                            "grade": 3,
+                                                                            "content": "이 프로젝트에 지원하고 싶습니다.",
+                                                                            "appliedAt": "2025.11.03",
+                                                                            "position": {
+                                                                                "desc": "백엔드",
+                                                                                "name": "BACK_END"
+                                                                            },
+                                                                            "skills": [
+                                                                                {
+                                                                                    "desc": "MySQL",
+                                                                                    "name": "MYSQL"
+                                                                                },
+                                                                                {
+                                                                                    "desc": "Spring Boot",
+                                                                                    "name": "SPRING_BOOT"
+                                                                                },
+                                                                                {
+                                                                                    "desc": "Java",
+                                                                                    "name": "JAVA"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "page": {
+                                                                "size": 5,
+                                                                "number": 0,
+                                                                "totalElements": 2,
+                                                                "totalPages": 1
+                                                            }
+                                                        }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "**인증 필요**",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = APIResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "UNAUTHORIZED",
+                                                        "message": "인증이 필요합니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "**서버 오류 발생**",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = APIResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "INTERNAL_ERROR",
+                                                        "message": "서버 오류가 발생했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    ResponseEntity<APIResponse<Page<RecruitmentWithAppsResponseDto>>> getMyProjects(
+            @PageableDefault(size = 5) Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
 

--- a/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/repository/ProjectRepository.java
@@ -2,6 +2,8 @@ package com.wagglex2.waggle.domain.project.repository;
 
 import com.wagglex2.waggle.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,6 +20,20 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             type = EntityGraph.EntityGraphType.LOAD
     )
     Optional<Project> findWithAllById(Long id);
+
+    /**
+     * 특정 사용자가 작성한, 삭제되지 않은 프로젝트 공고를 페이지 단위로 조회한다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param pageable 페이지네이션 정보
+     * @return 삭제되지 않은 프로젝트 공고의 페이지(Page) 객체
+     */
+    @Query("""
+        Select p FROM Project p
+        WHERE p.user.id = :userId
+        AND p.status != com.wagglex2.waggle.domain.common.type.RecruitmentStatus.CANCELED
+    """)
+    Page<Project> findAllByUserId(@Param("userId") Long userId,Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Project p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/ProjectService.java
@@ -1,5 +1,6 @@
 package com.wagglex2.waggle.domain.project.service;
 
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectCreationRequestDto;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectSearchCondition;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectUpdateRequestDto;
@@ -15,6 +16,7 @@ public interface ProjectService {
     ProjectDetailResponseDto getProject(Long viewerId, Long projectId);
     Page<ProjectSummaryResponseDto> getProjectSummaries(Long viewerId, ProjectSearchCondition condition, Pageable pageable);
     List<ProjectSummaryResponseDto> getProjectSummariesByIds(List<Long> projectIds);
+    Page<RecruitmentWithAppsResponseDto> getAllByUserId(Long userId, Pageable pageable);
     void updateProject(Long userId, Long projectId, ProjectUpdateRequestDto updateDto);
     void deleteProject(Long userId, Long projectId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -2,6 +2,11 @@ package com.wagglex2.waggle.domain.project.service.serviceImpl;
 
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
+import com.wagglex2.waggle.common.validator.PageableValidator;
+import com.wagglex2.waggle.domain.application.dto.response.AppContentProjectResponseDto;
+import com.wagglex2.waggle.domain.application.entity.Application;
+import com.wagglex2.waggle.domain.application.service.ApplicationService;
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectCreationRequestDto;
 import com.wagglex2.waggle.domain.project.dto.request.ProjectSearchCondition;
@@ -19,6 +24,7 @@ import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
@@ -26,14 +32,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ProjectServiceImpl implements ProjectService {
+
+    private static final Set<String> PROJECT_SORT_FIELDS = Set.of("createdAt");
     private final ProjectRepository projectRepository;
     private final UserService userService;
     private final TeamService teamService;
+    private final ApplicationService applicationService;
+    private final PageableValidator pageableValidator;
 
     @Transactional
     @Override
@@ -102,6 +115,59 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     public List<ProjectSummaryResponseDto> getProjectSummariesByIds(List<Long> projectIds) {
         return projectRepository.getProjectSummariesByIds(projectIds);
+    }
+
+    @PreAuthorize("#userId == authentication.principal.userId")
+    @Override
+    public Page<RecruitmentWithAppsResponseDto> getAllByUserId(
+            @P("userId") Long userId,
+            Pageable pageable
+    ) {
+        pageableValidator.validate(pageable);
+        pageableValidator.validateSort(pageable, PROJECT_SORT_FIELDS);
+
+        Page<Project> projects = projectRepository.findAllByUserId(userId, pageable);
+
+        // 공고 ID 목록
+        List<Long> projectIds = projects.stream()
+                .map(Project::getId)
+                .toList();
+
+        // 공고 ID로 application 전체 조회
+        List<Application> applications = applicationService.findAllByRecruitmentIds(projectIds);
+
+        // 공고ID -> applications 매핑 Map 생성
+        Map<Long, List<Application>> appsByRecruitmentId = applications.stream()
+                .collect(Collectors.groupingBy(
+                        app -> app.getRecruitment().getId())
+                );
+
+        // DTO 조합
+        List<RecruitmentWithAppsResponseDto> content = projects.stream()
+                .map(p -> new RecruitmentWithAppsResponseDto(
+                        p.getId(),
+                        p.getTitle(),
+                        p.getDeadline(),
+                        appsByRecruitmentId.getOrDefault(
+                                        p.getId(),
+                                        List.of()
+                                ).stream()
+                                .map(a -> new AppContentProjectResponseDto(
+                                        a.getId(),
+                                        a.getApplicant().getId(),
+                                        a.getApplicant().getNickname(),
+                                        a.getMeetingType(),
+                                        a.getGrade(),
+                                        a.getContent(),
+                                        a.getCreatedAt(),
+                                        a.getPosition(),
+                                        a.getSkills()
+                                ))
+                                .toList()
+                ))
+                .toList();
+
+        return new PageImpl<>(content, pageable, projects.getTotalElements());
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/study/controller/StudyController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/controller/StudyController.java
@@ -3,12 +3,18 @@ package com.wagglex2.waggle.domain.study.controller;
 
 import com.wagglex2.waggle.common.response.APIResponse;
 import com.wagglex2.waggle.common.security.CustomUserDetails;
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.study.dto.request.StudyCreationRequestDto;
 import com.wagglex2.waggle.domain.study.dto.request.StudyUpdateRequestDto;
 import com.wagglex2.waggle.domain.study.dto.response.StudyResponseDto;
 import com.wagglex2.waggle.domain.study.service.StudyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,6 +51,25 @@ public class StudyController {
         );
     }
 
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<APIResponse<Page<RecruitmentWithAppsResponseDto>>> getMyStudies(
+            @PageableDefault(size = 5) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        PageRequest pageRequest = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<RecruitmentWithAppsResponseDto> studiesWithApps = studyService.getAllByUserId(userDetails.getUserId(), pageRequest);
+
+        return ResponseEntity.ok(
+                APIResponse.ok("내 스터디 공고 목록을 성공적으로 조회하였습니다.", studiesWithApps)
+        );
+    }
+
     @PutMapping("/{studyId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<APIResponse<Void>> updateStudy(
@@ -70,5 +95,4 @@ public class StudyController {
                 APIResponse.ok("스터디 공고를 성공적으로 삭제하였습니다.")
         );
     }
-
 }

--- a/src/main/java/com/wagglex2/waggle/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/repository/StudyRepository.java
@@ -2,6 +2,8 @@ package com.wagglex2.waggle.domain.study.repository;
 
 import com.wagglex2.waggle.domain.study.entity.Study;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,6 +20,20 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
             type = EntityGraph.EntityGraphType.LOAD
     )
     Optional<Study> findWithAllById(Long studyId);
+
+    /**
+     * 특정 사용자가 작성한, 삭제되지 않은 스터디 공고를 페이지 단위로 조회한다.
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param pageable 페이지네이션 정보
+     * @return 삭제되지 않은 스터디 공고의 페이지(Page) 객체
+     */
+    @Query("""
+        Select s FROM Study s
+        WHERE s.user.id = :userId
+        AND s.status != com.wagglex2.waggle.domain.common.type.RecruitmentStatus.CANCELED
+    """)
+    Page<Study> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("update Study a set a.viewCount = a.viewCount + 1 where a.id = :studyId")

--- a/src/main/java/com/wagglex2/waggle/domain/study/service/StudyService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/service/StudyService.java
@@ -1,12 +1,16 @@
 package com.wagglex2.waggle.domain.study.service;
 
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.study.dto.request.StudyCreationRequestDto;
 import com.wagglex2.waggle.domain.study.dto.request.StudyUpdateRequestDto;
 import com.wagglex2.waggle.domain.study.dto.response.StudyResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface StudyService {
     Long createStudy(StudyCreationRequestDto studyCreationRequestDto, Long userId);
     StudyResponseDto getStudy(Long viewerId, Long studyId);
+    Page<RecruitmentWithAppsResponseDto> getAllByUserId(Long userId, Pageable pageable);
     void updateStudy(Long userId, Long studyId, StudyUpdateRequestDto updateDto);
     void deleteStudy(Long userId, Long studyId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/study/service/serviceImpl/StudyServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/service/serviceImpl/StudyServiceImpl.java
@@ -2,6 +2,11 @@ package com.wagglex2.waggle.domain.study.service.serviceImpl;
 
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
+import com.wagglex2.waggle.common.validator.PageableValidator;
+import com.wagglex2.waggle.domain.application.dto.response.AppContentSimpleResponseDto;
+import com.wagglex2.waggle.domain.application.entity.Application;
+import com.wagglex2.waggle.domain.application.service.ApplicationService;
+import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.study.dto.request.StudyCreationRequestDto;
 import com.wagglex2.waggle.domain.study.dto.request.StudyUpdateRequestDto;
@@ -12,17 +17,28 @@ import com.wagglex2.waggle.domain.study.service.StudyService;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class StudyServiceImpl implements StudyService {
+    private static final Set<String> STUDY_SORT_FIELDS = Set.of("createdAt");
     private final StudyRepository studyRepository;
     private final UserService userService;
+    private final ApplicationService applicationService;
+    private final PageableValidator pageableValidator;
 
     @Transactional
     @Override
@@ -58,6 +74,57 @@ public class StudyServiceImpl implements StudyService {
         }
 
         return StudyResponseDto.fromEntity(study);
+    }
+
+    @PreAuthorize("#userId == authentication.principal.userId")
+    @Override
+    public Page<RecruitmentWithAppsResponseDto> getAllByUserId(
+            @P("userId") Long userId,
+            Pageable pageable
+    ) {
+        pageableValidator.validate(pageable);
+        pageableValidator.validateSort(pageable, STUDY_SORT_FIELDS);
+
+        Page<Study> studies = studyRepository.findAllByUserId(userId, pageable);
+
+        // 공고 ID 목록
+        List<Long> assignmnetIds = studies.stream()
+                .map(Study::getId)
+                .toList();
+
+        // 공고 ID로 application 전체 조회
+        List<Application> applications = applicationService.findAllByRecruitmentIds(assignmnetIds);
+
+        // 공고 ID -> applications 매핑 Map 생성
+        Map<Long, List<Application>> appsByRecruitmentId = applications.stream()
+                .collect(Collectors.groupingBy(
+                        app -> app.getRecruitment().getId())
+                );
+
+        // DTO 조합
+        List<RecruitmentWithAppsResponseDto> content = studies.stream()
+                .map(s -> new RecruitmentWithAppsResponseDto(
+                        s.getId(),
+                        s.getTitle(),
+                        s.getDeadline(),
+                        appsByRecruitmentId.getOrDefault(
+                                        s.getId(),
+                                        List.of()
+                                ).stream()
+                                .map(app -> new AppContentSimpleResponseDto(
+                                        app.getId(),
+                                        app.getApplicant().getId(),
+                                        app.getApplicant().getNickname(),
+                                        app.getMeetingType(),
+                                        app.getGrade(),
+                                        app.getContent(),
+                                        app.getCreatedAt()
+                                ))
+                                .toList()
+                ))
+                .toList();
+
+        return new PageImpl<>(content, pageable, studies.getTotalElements());
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")


### PR DESCRIPTION
- 지원 내용만을 갖는 응답 DTO 생성
- 공고 정보와 각 공고에 대한 지원 목록(List)을 담는 최종 응답 DTO 생성: `RecruitmentWithAppsResponseDto`
- 카테고리별 `내 공고 조회 API` 구현

---

### 흐름

1. 특정 사용자의 공고 목록 조회 (페이징 처리) 
2. 1에서 조회한 공고들의 ID 리스트를 통해 해당되는 모든 지원 정보 조회
3. 지원 정보 리스트를 `Map<공고 ID, List<공고별 지원>>` 형식으로 가공
4. 조회한 모든 공고에 대해 `List<RecruitmentWithAppsResponseDto>` 생성