### PR TITLE
fix: 프로젝트 지원 수락 시 포지션 할당

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -25,7 +25,7 @@ import com.wagglex2.waggle.domain.study.entity.Study;
 import com.wagglex2.waggle.domain.team.entity.Team;
 import com.wagglex2.waggle.domain.team.service.TeamService;
 import com.wagglex2.waggle.domain.team_member.entity.TeamMember;
-import com.wagglex2.waggle.domain.team_member.entity.type.TeamRole;
+import com.wagglex2.waggle.domain.team_member.service.TeamMemberService;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +53,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     private final UserService userService;
     private final RecruitmentService recruitmentService;
     private final TeamService teamService;
+    private final TeamMemberService teamMemberService;
     private final ApplicationEventPublisher publisher;
 
     @PreAuthorize("#userId == authentication.principal.userId")
@@ -211,7 +212,7 @@ public class ApplicationServiceImpl implements ApplicationService {
 
         // 팀에 추가
         Team team = teamService.findByRecruitmentId(recruitment.getId());
-        TeamMember newMember = new TeamMember(team, application.getApplicant(), TeamRole.MEMBER);
+        TeamMember newMember = teamMemberService.createMember(team, application);
         team.addMember(newMember);
 
         // 이벤트 발행

--- a/src/main/java/com/wagglex2/waggle/domain/team/dto/response/TeamResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team/dto/response/TeamResponseDto.java
@@ -1,5 +1,6 @@
 package com.wagglex2.waggle.domain.team.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wagglex2.waggle.domain.common.dto.response.PeriodResponseDto;
 import com.wagglex2.waggle.domain.common.entity.BaseRecruitment;
 import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
@@ -32,6 +33,7 @@ import java.util.List;
  * </ul>
  * </p>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TeamResponseDto(
         Long id,
         Long recruitmentId,

--- a/src/main/java/com/wagglex2/waggle/domain/team_member/dto/response/TeamMemberResponseDto.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team_member/dto/response/TeamMemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.wagglex2.waggle.domain.team_member.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wagglex2.waggle.domain.common.type.PositionType;
 import com.wagglex2.waggle.domain.team_member.entity.TeamMember;
 import com.wagglex2.waggle.domain.team_member.entity.type.TeamRole;
@@ -18,6 +19,7 @@ import com.wagglex2.waggle.domain.team_member.entity.type.TeamRole;
  * </ul>
  * </p>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TeamMemberResponseDto(
         Long userId,
         // TODO ProfileImage

--- a/src/main/java/com/wagglex2/waggle/domain/team_member/entity/TeamMember.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team_member/entity/TeamMember.java
@@ -74,10 +74,19 @@ public class TeamMember {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    // 과제, 스터디
     public TeamMember(Team team, User user, TeamRole role) {
         this.team = team;
         this.user = user;
         this.role = role;
+    }
+
+    // 프로젝트
+    public TeamMember(Team team, User user, TeamRole role, PositionType position) {
+        this.team = team;
+        this.user = user;
+        this.role = role;
+        this.position = position;
     }
 
     public void setTeam(Team team) {

--- a/src/main/java/com/wagglex2/waggle/domain/team_member/service/TeamMemberService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team_member/service/TeamMemberService.java
@@ -1,5 +1,42 @@
 package com.wagglex2.waggle.domain.team_member.service;
 
+import com.wagglex2.waggle.domain.application.entity.Application;
+import com.wagglex2.waggle.domain.application.service.ApplicationService;
+import com.wagglex2.waggle.domain.team.entity.Team;
+import com.wagglex2.waggle.domain.team_member.entity.TeamMember;
+
 public interface TeamMemberService {
+
+    /**
+     * 주어진 {@link Team} 과 {@link Application} 정보를 기반으로 새로운 {@link TeamMember} 를 생성한다.
+     * <p>
+     * 이 메서드는 지원서가 승인될 때 지원자를 팀원으로 추가하기 위해
+     * <b>{@link ApplicationService#acceptApplication}에서 호출되도록 설계한 도메인 규칙 메서드</b>이다.
+     * <p>
+     * 팀원 생성 규칙은 다음과 같다.
+     * <ul>
+     *     <li>모집 카테고리가 {@code PROJECT} 인 경우, 지원서에 포함된 포지션 정보를 사용하여 팀원을 생성한다.</li>
+     *     <li>{@code ASSIGNMENT}, {@code STUDY}의 경우, 포지션 없이 일반 팀원으로 생성한다.</li>
+     * </ul>
+     *
+     * @param team 팀원으로 추가될 팀을 의미한다.
+     * @param application 승인된 지원서를 의미한다.
+     * @return 생성된 TeamMember 객체를 반환한다.
+     */
+    TeamMember createMember(Team team, Application application);
+
+    /**
+     * 팀 멤버 삭제 (리더 권한 전용)
+     *
+     * <p>해당 메서드는 특정 팀의 리더가 팀 멤버를 강제 탈퇴(삭제)시키는 로직을 수행한다.</p>
+     * <p>공고 엔티티(@Version 기반) 현재 인원 감소를 수행하며, 동시성 충돌 시 OptimisticLockException이 발생할 수 있다.</p>
+     *
+     * <ul>
+     *   <li>리더만 멤버 삭제 가능</li>
+     *   <li>리더 본인은 자신을 삭제할 수 없음</li>
+     *   <li>존재하지 않는 팀이나 멤버에 대한 삭제 시 예외 발생</li>
+     *   <li>모든 검증을 통과한 경우 실제 데이터 삭제 수행</li>
+     * </ul>
+     */
     void removeMember(Long teamId, Long removerId ,Long targetId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/team_member/service/serviceImpl/TeamMemberServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team_member/service/serviceImpl/TeamMemberServiceImpl.java
@@ -2,11 +2,10 @@ package com.wagglex2.waggle.domain.team_member.service.serviceImpl;
 
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
-import com.wagglex2.waggle.domain.assignment.entity.Assignment;
+import com.wagglex2.waggle.domain.application.entity.Application;
 import com.wagglex2.waggle.domain.common.entity.BaseRecruitment;
 import com.wagglex2.waggle.domain.common.service.RecruitmentService;
-import com.wagglex2.waggle.domain.project.entity.Project;
-import com.wagglex2.waggle.domain.study.entity.Study;
+import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import com.wagglex2.waggle.domain.team.entity.Team;
 import com.wagglex2.waggle.domain.team.service.TeamService;
 import com.wagglex2.waggle.domain.team_member.entity.TeamMember;
@@ -30,19 +29,20 @@ public class TeamMemberServiceImpl implements TeamMemberService {
     private final TeamService teamService;
     private final RecruitmentService recruitmentService;
 
-    /**
-     * 팀 멤버 삭제 (리더 권한 전용)
-     *
-     * <p>해당 메서드는 특정 팀의 리더가 팀 멤버를 강제 탈퇴(삭제)시키는 로직을 수행한다.</p>
-     * <p>공고 엔티티(@Version 기반) 현재 인원 감소를 수행하며, 동시성 충돌 시 OptimisticLockException이 발생할 수 있다.</p>
-     *
-     * <ul>
-     *   <li>리더만 멤버 삭제 가능</li>
-     *   <li>리더 본인은 자신을 삭제할 수 없음</li>
-     *   <li>존재하지 않는 팀이나 멤버에 대한 삭제 시 예외 발생</li>
-     *   <li>모든 검증을 통과한 경우 실제 데이터 삭제 수행</li>
-     * </ul>
-     */
+    @Override
+    public TeamMember createMember(Team team, Application application) {
+        if (application.getRecruitment().getCategory() == RecruitmentCategory.PROJECT) {
+            return new TeamMember(
+                    team,
+                    application.getApplicant(),
+                    TeamRole.MEMBER,
+                    application.getPosition()
+            );
+        }
+
+        return new TeamMember(team, application.getApplicant(), TeamRole.MEMBER);
+    }
+
     @Override
     @Transactional
     @PreAuthorize("#removerId == authentication.principal.userId")


### PR DESCRIPTION
- TeamMember 엔티티 관련 생성자 추가
- TeamMember 생성 책임을 TeamMemberService로 분리
- 관련 응답 DTO `JsonInclude.Include.NON_NULL` 추가