### PR TITLE
feat: 전역 예외 처리 추가

### DIFF
--- a/src/main/java/com/wagglex2/waggle/common/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/wagglex2/waggle/common/controller/GlobalExceptionHandler.java
@@ -4,8 +4,10 @@ import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
 import com.wagglex2.waggle.common.response.APIResponse;
 import com.wagglex2.waggle.common.response.ValidationError;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,7 +16,9 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -147,5 +151,34 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(APIResponse.error("NOT_FOUND", message));
+    }
+
+    /**
+     * HttpRequestMethodNotSupportedException 예외 처리
+     * <p>
+     * 클라이언트가 요청한 URL은 존재하지만, 해당 URL에서 요청한 HTTP 메서드가 허용되지 않을 경우 발생하는 예외를 처리한다.
+     *
+     * <p>
+     * 처리 결과로 클라이언트에게 HTTP 405 상태 코드와 함께 ErrorCode 및 요청 정보, 허용된 메서드를 반환한다.
+     *
+     * @param ex {@link HttpRequestMethodNotSupportedException} - 요청된 메서드 정보와 허용된 메서드 목록 포함
+     * @param request {@link HttpServletRequest} - 요청 URL 정보를 얻기 위해 사용
+     * @return {@link ResponseEntity} - {@link APIResponse}를 포함한 405 Method Not Allowed 응답
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<APIResponse<Map<String, Object>>> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException ex,
+            HttpServletRequest request
+    ) {
+        String[] allowed = ex.getSupportedMethods();
+
+        // 순서 보장을 위해 LinkedHashMap 사용
+        Map<String, Object> errorDetail = new LinkedHashMap<>();
+        errorDetail.put("url", request.getRequestURI());
+        errorDetail.put("requested", ex.getMethod());
+        errorDetail.put("allowed", allowed != null ? allowed : "허용된 메서드 없음");
+
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(APIResponse.error(ErrorCode.METHOD_NOT_ALLOWED, errorDetail));
     }
 }

--- a/src/main/java/com/wagglex2/waggle/common/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/wagglex2/waggle/common/controller/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.wagglex2.waggle.common.controller;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.wagglex2.waggle.common.error.ErrorCode;
 import com.wagglex2.waggle.common.exception.BusinessException;
 import com.wagglex2.waggle.common.response.APIResponse;
@@ -7,6 +9,7 @@ import com.wagglex2.waggle.common.response.ValidationError;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -180,5 +183,65 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
                 .body(APIResponse.error(ErrorCode.METHOD_NOT_ALLOWED, errorDetail));
+    }
+
+    /**
+     * HttpMessageNotReadableException 예외 처리
+     * <p>
+     * 클라이언트가 보낸 HTTP 메시지 Body(JSON 등)를 읽을 수 없거나,
+     * JSON 필드 값이 잘못되어 역직렬화에 실패한 경우 발생하는 예외를 처리한다.
+     *
+     * <p>
+     * 처리 과정에서 다음 정보를 추출하여 클라이언트에 반환한다.
+     * <ul>
+     *     <li>field: 문제가 된 JSON 필드 이름 (존재하는 경우)</li>
+     *     <li>invalidValue: 클라이언트가 요청한 값 (잘못된 값)</li>
+     *     <li>expectedType: 해당 필드가 기대하는 타입 (Enum, 숫자, 날짜 등)</li>
+     * </ul>
+     *
+     * <p>
+     * 일반적인 JSON 파싱 오류나 구조 오류의 경우에는 별도의 메시지로 안내한다.
+     *
+     * @param ex {@link HttpMessageNotReadableException} - HTTP Body 파싱 실패 정보 포함
+     * @return {@link ResponseEntity} - {@link APIResponse}를 포함한 400 Bad Request 응답
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<APIResponse<Map<String, Object>>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        Throwable cause = ex.getCause();
+        Map<String, Object> errorDetail = new LinkedHashMap<>();
+
+        if (cause instanceof JsonMappingException jme) {
+
+            // 어떤 필드에서 오류 났는지 path 추출
+            List<JsonMappingException.Reference> path = jme.getPath();
+            if (!path.isEmpty()) {
+                String fieldName = path.get(path.size() - 1).getFieldName();
+                errorDetail.put("field", fieldName);
+            }
+
+            // InvalidFormatException -> 잘못된 값 + 기대 타입까지 추출
+            if (cause instanceof InvalidFormatException ife) {
+
+                // 잘못된 값(Enum, 날짜, 숫자 등)
+                Object invalidValue = ife.getValue();
+                errorDetail.put("invalidValue", invalidValue);
+
+                // 기대 타입(Class)
+                Class<?> targetType = ife.getTargetType();
+                if (targetType != null) {
+                    errorDetail.put("expectedType", targetType.getSimpleName());
+                } else {
+                    errorDetail.put("expectedType", "알 수 없음");
+                }
+
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(APIResponse.error(ErrorCode.INVALID_JSON_FIELD, errorDetail));
+            }
+
+        }
+
+        // 일반적인 파싱 실패 (예: 잘못된 JSON 문법 오류 등)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(APIResponse.error(ErrorCode.UNREADABLE_JSON));
     }
 }

--- a/src/main/java/com/wagglex2/waggle/common/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/wagglex2/waggle/common/controller/GlobalExceptionHandler.java
@@ -244,4 +244,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(APIResponse.error(ErrorCode.UNREADABLE_JSON));
     }
+
+    /**
+     * 일반적인 서버 예외 처리
+     * <p>
+     * 애플리케이션 실행 중 처리되지 않은 모든 예외를 처리한다.
+     * <p>
+     *
+     * <p>
+     * 주로 예기치 않은 서버 오류, NullPointerException, RuntimeException 등
+     * 처리되지 않은 예외를 포괄적으로 잡기 위해 사용된다.
+     *
+     * @param ex {@link Exception} - 처리되지 않은 예외
+     * @return {@link ResponseEntity} - {@link APIResponse}를 포함한 500 Internal Server Error 응답
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<APIResponse<Void>> handleException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(APIResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
 }

--- a/src/main/java/com/wagglex2/waggle/common/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/wagglex2/waggle/common/controller/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.List;
 
@@ -119,5 +120,32 @@ public class GlobalExceptionHandler {
     public ResponseEntity<APIResponse<Void>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
         return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
                 .body(APIResponse.error(ErrorCode.FILE_SIZE_TOO_LARGE));
+    }
+
+    /**
+     * NoResourceFoundException 예외 처리
+     * <p>
+     * 클라이언트가 잘못된 URL 경로로 요청을 보낸 경우 발생하는 예외를 처리한다.
+     * <p>
+     * 예시:
+     * <ul>
+     *     <li>잘못된 경로 요청 (예: GET /api/v1/apple)</li>
+     * </ul>
+     * <p>
+     * 처리 결과로 클라이언트에게 HTTP 404 상태 코드와 함께 상세 메시지를 반환한다.
+     *
+     * @param ex {@link NoResourceFoundException} - 요청한 리소스를 찾을 수 없는 정보 포함
+     * @return {@link ResponseEntity} - {@link APIResponse}를 포함한 404 에러 응답
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<APIResponse<String>> handleNoResourceFoundException(NoResourceFoundException ex) {
+        String message = String.format(
+                "잘못된 URL입니다. (%s %s)",
+                ex.getHttpMethod(),
+                ex.getResourcePath()
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(APIResponse.error("NOT_FOUND", message));
     }
 }

--- a/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
+++ b/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
@@ -37,6 +37,8 @@ public enum ErrorCode {
     INVALID_FILE_FORMAT(HttpStatus.BAD_REQUEST, "INVALID_FILE_FORMAT", "지원하지 않는 파일 형식입니다. jpg, jpeg, png만 가능합니다."),
     USER_ALREADY_COMPLETED_BASIC_INFO(HttpStatus.BAD_REQUEST, "USER_ALREADY_COMPLETED_BASIC_INFO", "이미 기본 정보를 입력한 사용자입니다."),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "유효하지 않은 인자 값입니다."),
+    INVALID_JSON_FIELD(HttpStatus.BAD_REQUEST, "INVALID_JSON_FIELD", "요청 본문의 필드 값 형식이 올바르지 않습니다."),
+    UNREADABLE_JSON(HttpStatus.BAD_REQUEST, "UNREADABLE_JSON", "요청 본문을 읽을 수 없습니다."),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),

--- a/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
+++ b/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
@@ -84,6 +84,9 @@ public enum ErrorCode {
     TARGET_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "TARGET_MEMBER_NOT_FOUND", "삭제할 멤버를 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_NOT_FOUND", "알림을 찾을 수 없습니다."),
 
+    // 405
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "허용되지 않은 HTTP 메서드입니다."),
+
     // 406
     NOT_ACCEPTABLE(HttpStatus.NOT_ACCEPTABLE, "NOT_ACCEPTABLE", "응답 가능한 미디어 타입이 없습니다."),
 


### PR DESCRIPTION
-  잘못된 URL 경로로 요청을 보낸 경우 발생하는 예외 처리
- 요청한 URL은 존재하지만, 해당 URL에서 요청한 HTTP 메서드가 허용되지 않을 경우 발생하는 예외 처리
- JSON 요청 본문을 읽을 수 없거나, 필드 값이 잘못되어 역직렬화에 실패할 때 발생하는 예외 처리
- 따로 처리되지 않은 예외를 캐치하여, `INTERNAL_SERVER_ERROR` 처리