### PR TITLE
feat: 알림 읽음 처리 API 구현

### DIFF
--- a/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
+++ b/src/main/java/com/wagglex2/waggle/common/error/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
     CANNOT_REMOVE_NOT_LEADER(HttpStatus.FORBIDDEN, "CANNOT_DELETE_NOT_LEADER", "리더만 멤버를 삭제할 수 있습니다."),
     CANNOT_REMOVE_SELF(HttpStatus.FORBIDDEN, "CANNOT_DELETE_MYSELF", "자기 자신은 삭제할 수 없습니다."),
     CANNOT_DELETE_ANOTHER_USER_NOTIFICATION(HttpStatus.FORBIDDEN, "CANNOT_DELETE_ANOTHER_USER_NOTIFICATION", "다른 사용자의 알림은 삭제할 수 없습니다."),
+    CANNOT_READ_ANOTHER_USER_NOTIFICATION(HttpStatus.FORBIDDEN, "CANNOT_READ_ANOTHER_USER_NOTIFICATION", "다른 사용자의 알림은 읽을 수 없습니다."),
 
     // 404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/wagglex2/waggle/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/controller/NotificationController.java
@@ -48,6 +48,17 @@ public class NotificationController implements NotificationControllerDocs {
         return ResponseEntity.ok(APIResponse.ok(message, notifications));
     }
 
+    @PatchMapping("{notificationId}/read")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<APIResponse<Void>> markAsRead(
+            @PathVariable("notificationId") Long notificationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        notificationService.markAsRead(userDetails.getUserId(), notificationId);
+
+        return ResponseEntity.ok(APIResponse.ok("알림을 읽음 처리하였습니다."));
+    }
+
     @DeleteMapping("{notificationId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<APIResponse<Void>> deleteById(

--- a/src/main/java/com/wagglex2/waggle/domain/notification/controller/docs/NotificationControllerDocs.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/controller/docs/NotificationControllerDocs.java
@@ -21,10 +21,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Notification(알림)", description = "알림 관련 API")
 public interface NotificationControllerDocs {
@@ -329,6 +326,122 @@ public interface NotificationControllerDocs {
     ResponseEntity<APIResponse<Page<NotificationResponseDto>>> getMyNotificationsByCategory(
             @RequestParam(value = "category", required = false) RecruitmentCategory category,
             @PageableDefault(size = 5) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "알림 읽음 처리",
+            description = """
+                    알림을 읽음 처리한다.<br>
+                    이미 읽음 처리된 알림이라도, 예외 없이 성공(200)으로 응답한다.
+                    """,
+            security = @SecurityRequirement(name = "Bearer Token"),
+            parameters = {
+                    @Parameter(
+                            name = "notificationId",
+                            description = "읽음 처리하려는 알림 ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            example = "13"
+                    )
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "알림 읽음 처리 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = APIResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "SUCCESS",
+                                                        "message": "알림을 읽음 처리하였습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = APIResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "UNAUTHORIZED",
+                                                        "message": "인증이 필요합니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "알림을 읽음 처리할 권한이 없는 경우",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = APIResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "CANNOT_READ_ANOTHER_USER_NOTIFICATION",
+                                                        "message": "다른 사용자의 알림은 읽을 수 없습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 알림이 존재하지 않는 경우",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = APIResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "NOTIFICATION_NOT_FOUND",
+                                                        "message": "알림을 찾을 수 없습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 발생",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = APIResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            value = """
+                                                    {
+                                                        "code": "INTERNAL_ERROR",
+                                                        "message": "서버 오류가 발생했습니다."
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    @PatchMapping("{notificationId}/read")
+    @PreAuthorize("isAuthenticated()")
+    ResponseEntity<APIResponse<Void>> markAsRead(
+            @PathVariable("notificationId") Long notificationId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
 

--- a/src/main/java/com/wagglex2/waggle/domain/notification/entity/Notification.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/entity/Notification.java
@@ -52,4 +52,8 @@ public class Notification {
         this.application = application;
         this.type = type;
     }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/service/NotificationService.java
@@ -21,6 +21,7 @@ public interface NotificationService {
      */
     void createNotification(Long senderId, Long receiverId, Long applicationId, NotificationType type);
     Page<NotificationResponseDto> getAllByUserIdAndCategory(Long receiverId, RecruitmentCategory category, Pageable pageable);
+    void markAsRead(Long receiverId, Long notificationId);
     void deleteById(Long userId, Long notificationId);
 
     /**

--- a/src/main/java/com/wagglex2/waggle/domain/notification/service/serviceImpl/NotificationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/service/serviceImpl/NotificationServiceImpl.java
@@ -58,6 +58,26 @@ public class NotificationServiceImpl implements NotificationService {
         return notificationRepository.getAllByUserIdAndCategory(receiverId, category, pageable);
     }
 
+    @PreAuthorize("#receiverId == authentication.principal.userId")
+    @Transactional
+    @Override
+    public void markAsRead(@P("receiverId") Long receiverId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        // 권한 검증
+        if (!receiverId.equals(notification.getReceiver().getId())) {
+            throw new BusinessException(ErrorCode.CANNOT_READ_ANOTHER_USER_NOTIFICATION);
+        }
+
+        // 이미 읽음 처리된 경우 - 예외를 던지지 않음
+        if (notification.isRead()) {
+            return;
+        }
+
+        notification.markAsRead();
+    }
+
     @PreAuthorize("#userId == authentication.principal.userId")
     @Transactional
     @Override


### PR DESCRIPTION
이미 읽음 처리된 알림도 따로 예외 처리하지 않고 성공(200)으로 응답
이유: 단순 상태 변경용이며, 프론트에서 예외에 따른 처리를 고려하지 않아도 되기 때문

단, 의미 없는 update 쿼리 방지를 위한 분기 적용