### PR TITLE
Merge | Chore: 삭제된 User 제외 후 조회 [BE-172]

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/user/entity/User.java
+++ b/src/main/java/com/wagglex2/waggle/domain/user/entity/User.java
@@ -47,20 +47,20 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false)
     private String username;
 
     @Column(nullable = false, length = 60)
     private String password;
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false)
     private String email;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private University university;
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false)
     private String nickname;
 
     private Integer grade;

--- a/src/main/java/com/wagglex2/waggle/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.wagglex2.waggle.domain.user.repository;
 
 import com.wagglex2.waggle.domain.user.entity.User;
+import com.wagglex2.waggle.domain.user.entity.type.UserStatus;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,10 +11,13 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUsername(String username);
-    boolean existsByEmail(String email);
-    boolean existsByUsername(String username);
-    boolean existsByNickname(String nickname);
+
+    Optional<User> findByIdAndStatusNot(Long id, UserStatus status);
+    Optional<User> findByUsernameAndStatusNot(String username, UserStatus status);
+    boolean existsByIdAndStatusNot(Long id, UserStatus status);
+    boolean existsByEmailAndStatusNot(String email, UserStatus status);
+    boolean existsByUsernameAndStatusNot(String username, UserStatus status);
+    boolean existsByNicknameAndStatusNot(String nickname, UserStatus status);
 
     /**
      * 주어진 userId에 해당하는 User 엔티티를 조회하면서
@@ -22,6 +26,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * @param id 조회할 User의 식별자
      * @return id에 해당하는 User와 그 User의 skills 컬렉션을 포함한 Optional
      */
-    @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.skills WHERE u.id = :id")
-    Optional<User> findByIdWithSkills(@Param("id") Long id);
+    @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.skills WHERE u.id = :id AND u.status != :status")
+    Optional<User> findByIdAndStatusNotWithSkills(@Param("id") Long id, @Param("status") UserStatus status);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/user/service/serviceImpl/UserServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/user/service/serviceImpl/UserServiceImpl.java
@@ -41,40 +41,40 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public User findByUsername(String username) {
-        return userRepository.findByUsername(username)
+        return userRepository.findByUsernameAndStatusNot(username, UserStatus.WITHDRAWN)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Override
     public User findById(Long id) {
-        return userRepository.findById(id)
+        return userRepository.findByIdAndStatusNot(id, UserStatus.WITHDRAWN)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Override
     public User findByIdWithSkills(Long id) {
-        return userRepository.findByIdWithSkills(id)
+        return userRepository.findByIdAndStatusNotWithSkills(id, UserStatus.WITHDRAWN)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Override
     public boolean existsById(Long id) {
-        return userRepository.existsById(id);
+        return userRepository.existsByIdAndStatusNot(id, UserStatus.WITHDRAWN);
     }
 
     @Override
     public boolean existsByEmail(String email) {
-        return userRepository.existsByEmail(email);
+        return userRepository.existsByEmailAndStatusNot(email, UserStatus.WITHDRAWN);
     }
 
     @Override
     public boolean existsByUsername(String username) {
-        return userRepository.existsByUsername(username);
+        return userRepository.existsByUsernameAndStatusNot(username, UserStatus.WITHDRAWN);
     }
 
     @Override
     public boolean existsByNickname(String nickname) {
-        return userRepository.existsByNickname(nickname);
+        return userRepository.existsByNicknameAndStatusNot(nickname, UserStatus.WITHDRAWN);
     }
 
     /**
@@ -291,6 +291,7 @@ public class UserServiceImpl implements UserService {
      * @return 업로드된 사용자 정보를 담은 UserResponseDto
      */
     @Override
+    @Transactional
     @PreAuthorize("#userId == authentication.principal.userId")
     public UserResponseDto uploadProfileImage(Long userId, MultipartFile file) {
         User user = findById(userId);
@@ -358,6 +359,7 @@ public class UserServiceImpl implements UserService {
      * @return 기본 이미지로 변경된 사용자 정보를 담은 UserResponseDto
      */
     @Override
+    @Transactional
     @PreAuthorize("#userId == authentication.principal.userId")
     public UserResponseDto deleteProfileImage(Long userId) {
         User user = findById(userId);


### PR DESCRIPTION
회원탈퇴 후 다시 회원가입을 가능하게 하기 위해 `User` 엔티티에서 `username`, `email`, `nickname` `unique=true` 제거

status가 `WITHDRAWN`이 아닌 것들만 조회하도록 수정