### PR TITLE
feat: 공고 모집 재개 시 지원 상태 변경 이벤트 처리

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/application/event/ApplicationEventListener.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/event/ApplicationEventListener.java
@@ -1,6 +1,7 @@
 package com.wagglex2.waggle.domain.application.event;
 
 import com.wagglex2.waggle.domain.application.service.ApplicationService;
+import com.wagglex2.waggle.domain.common.event.RecruitmentReopenedEvent;
 import com.wagglex2.waggle.domain.common.event.RecruitmentDeletedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -18,5 +19,11 @@ public class ApplicationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRecruitmentDeleted(RecruitmentDeletedEvent event) {
         applicationService.cancelApplication(event.recruitmentId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleRecruitmentReopened(RecruitmentReopenedEvent event) {
+        applicationService.updateAllByRecruitmentReopened(event.recruitmentId());
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
@@ -1,6 +1,7 @@
 package com.wagglex2.waggle.domain.application.repository;
 
 import com.wagglex2.waggle.domain.application.entity.Application;
+import com.wagglex2.waggle.domain.application.type.ApplicationStatus;
 import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -86,20 +87,28 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     void cancelAllByRecruitmentId(Long recruitmentId);
 
     /**
-     * 마감 상태였던 공고가 마감일 수정으로 인해 다시 모집 가능 상태(RECRUITING)가 된 경우,
-     * 해당 공고에 대한 모든 지원서를 '제출됨' 상태로 되돌린다.
+     * 특정 공고에 대한 모든 지원서의 상태를 조건에 맞춰 일괄 변경한다.
      *
-     * @param recruitmentId 마감 상태에서 모집 상태로 변경된 공고 ID
+     * <p>지원서 중 삭제되지 않았고 현재 상태가 {@code from}인 경우에만
+     * {@code to} 상태로 업데이트된다.
+     *
+     * @param recruitmentId 상태를 변경할 공고 ID
+     * @param from 현재 상태 조건
+     * @param to 변경할 목표 상태
      */
     @Modifying(clearAutomatically = true)
     @Query("""
         UPDATE Application a
-        SET a.status = com.wagglex2.waggle.domain.application.type.ApplicationStatus.SUBMITTED
+        SET a.status = :to
         WHERE a.recruitment.id = :recruitmentId
         AND a.isDeleted = false
-        AND a.status = com.wagglex2.waggle.domain.application.type.ApplicationStatus.CLOSED
+        AND a.status = :from
     """)
-    void updateAllByRecruitmentReopened(Long recruitmentId);
+    void updateStatusAllByRecruitmentId(
+            @Param("recruitmentId") Long recruitmentId,
+            @Param("from") ApplicationStatus from,
+            @Param("to") ApplicationStatus to
+    );
 
     /**
      * 마감된 공고에 대한 모든 지원 상태를 CLOSED로 변경한다.

--- a/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
@@ -68,7 +68,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     List<Application> findAllByRecruitmentIds(@Param("recruitmentIds") List<Long> recruitmentIds);
 
     /**
-     * 특정 공고에 대해 대한 모든 지원을 취소 상태(CANCELED)로 변경한다.
+     * 특정 공고에 대한 모든 지원을 취소 상태(CANCELED)로 변경한다.
      * <p>
      * 특정 공고가 삭제되는 경우, 그와 관련된 지원의 상태를 변경하는 용도이다.<br>
      * 대상은 삭제 처리 되지 않고, 대기 상태(SUBMITTED)인 지원이다.
@@ -84,6 +84,22 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
         AND a.status = com.wagglex2.waggle.domain.application.type.ApplicationStatus.SUBMITTED
     """)
     void cancelAllByRecruitmentId(Long recruitmentId);
+
+    /**
+     * 마감 상태였던 공고가 마감일 수정으로 인해 다시 모집 가능 상태(RECRUITING)가 된 경우,
+     * 해당 공고에 대한 모든 지원서를 '제출됨' 상태로 되돌린다.
+     *
+     * @param recruitmentId 마감 상태에서 모집 상태로 변경된 공고 ID
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Application a
+        SET a.status = com.wagglex2.waggle.domain.application.type.ApplicationStatus.SUBMITTED
+        WHERE a.recruitment.id = :recruitmentId
+        AND a.isDeleted = false
+        AND a.status = com.wagglex2.waggle.domain.application.type.ApplicationStatus.CLOSED
+    """)
+    void updateAllByRecruitmentReopened(Long recruitmentId);
 
     /**
      * 마감된 공고에 대한 모든 지원 상태를 CLOSED로 변경한다.

--- a/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/repository/ApplicationRepository.java
@@ -104,7 +104,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
         AND a.isDeleted = false
         AND a.status = :from
     """)
-    void updateStatusAllByRecruitmentId(
+    int updateStatusAllByRecruitmentId(
             @Param("recruitmentId") Long recruitmentId,
             @Param("from") ApplicationStatus from,
             @Param("to") ApplicationStatus to

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/ApplicationService.java
@@ -40,6 +40,17 @@ public interface ApplicationService {
     void cancelApplication(Long recruitmentId);
 
     /**
+     * 마감 상태였던 공고가 마감일 수정으로 인해 다시 모집 가능 상태(RECRUITING)가 된 경우,
+     * 해당 공고에 대한 모든 지원서를 '제출됨' 상태로 되돌린다.
+     * <p>
+     * 이 메서드는 {@link ApplicationEventListener} 이벤트 리스너에서 호출되어
+     * 마감일 수정에 따른 지원 상태 변경을 처리한다.
+     *
+     * @param recruitmentId 마감 상태에서 모집 상태로 변경된 공고의 ID
+     */
+    void updateAllByRecruitmentReopened(Long recruitmentId);
+
+    /**
      * 마감된 공고에 대한 모든 지원 상태를 CLOSED로 변경한다.
      */
     void closeApplicationsForClosedRecruitments();

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -394,8 +394,8 @@ public class ApplicationServiceImpl implements ApplicationService {
      * 이벤트 처리 재시도 실패 시 처리
      */
     @Recover
-    protected void recoverReopenEvent(TransientDataAccessException e, Long recruitmentId) {
-        log.error("공고 재개 시 지원 상태 업데이트 실패(재시도 모두 실패). recruitmentId={}, 예외타입={}, 메시지={}",
+    protected void recoverEvent(TransientDataAccessException e, Long recruitmentId) {
+        log.error("공고 삭제 및 재개에 따른 지원 상태 업데이트 실패(재시도 모두 실패) (recruitmentId={}, 예외타입={}, 메시지={})",
                 recruitmentId, e.getClass().getSimpleName(), e.getMessage(), e);
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -281,7 +281,11 @@ public class ApplicationServiceImpl implements ApplicationService {
     @Transactional
     @Override
     public void cancelApplication(Long recruitmentId) {
-        applicationRepository.cancelAllByRecruitmentId(recruitmentId);
+        applicationRepository.updateStatusAllByRecruitmentId(
+                recruitmentId,
+                ApplicationStatus.SUBMITTED,
+                ApplicationStatus.CANCELED
+        );
     }
 
     @Transactional
@@ -292,7 +296,11 @@ public class ApplicationServiceImpl implements ApplicationService {
     )
     @Override
     public void updateAllByRecruitmentReopened(Long recruitmentId) {
-        applicationRepository.updateAllByRecruitmentReopened(recruitmentId);
+        applicationRepository.updateStatusAllByRecruitmentId(
+                recruitmentId,
+                ApplicationStatus.CLOSED,
+                ApplicationStatus.SUBMITTED
+        );
     }
 
     @Transactional

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -287,10 +287,16 @@ public class ApplicationServiceImpl implements ApplicationService {
     )
     @Override
     public void cancelApplication(Long recruitmentId) {
-        applicationRepository.updateStatusAllByRecruitmentId(
+        int updated = applicationRepository.updateStatusAllByRecruitmentId(
                 recruitmentId,
                 ApplicationStatus.SUBMITTED,
                 ApplicationStatus.CANCELED
+        );
+
+        log.info(
+                "[지원 삭제 처리] 삭제 처리된 지원 건수: {} (recruitmentId={})",
+                updated,
+                recruitmentId
         );
     }
 
@@ -302,10 +308,16 @@ public class ApplicationServiceImpl implements ApplicationService {
     )
     @Override
     public void updateAllByRecruitmentReopened(Long recruitmentId) {
-        applicationRepository.updateStatusAllByRecruitmentId(
+        int updated = applicationRepository.updateStatusAllByRecruitmentId(
                 recruitmentId,
                 ApplicationStatus.CLOSED,
                 ApplicationStatus.SUBMITTED
+        );
+
+        log.info(
+                "[모집 재개] 지원 상태 변경 건수: {} (recruitmentId={})",
+                updated,
+                recruitmentId
         );
     }
 

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -32,6 +32,7 @@ import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -284,6 +285,17 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Transactional
+    @Retryable(
+            retryFor = TransientDataAccessException.class, // 일시적 DB 문제
+            noRetryFor = BusinessException.class,
+            maxAttempts = 3
+    )
+    @Override
+    public void updateAllByRecruitmentReopened(Long recruitmentId) {
+        applicationRepository.updateAllByRecruitmentReopened(recruitmentId);
+    }
+
+    @Transactional
     @Override
     public void closeApplicationsForClosedRecruitments() {
         int updated = applicationRepository.closeApplicationsForClosedRecruitments();
@@ -350,5 +362,14 @@ public class ApplicationServiceImpl implements ApplicationService {
     @Recover
     protected void recover(ObjectOptimisticLockingFailureException e, Long deciderId, Long applicationId) {
         throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * 이벤트 처리 재시도 실패 시 처리
+     */
+    @Recover
+    protected void recoverReopenEvent(TransientDataAccessException e, Long recruitmentId) {
+        log.error("공고 재개 시 지원 상태 업데이트 실패(재시도 모두 실패). recruitmentId={}, 예외타입={}, 메시지={}",
+                recruitmentId, e.getClass().getSimpleName(), e.getMessage(), e);
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -41,6 +41,7 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -148,7 +149,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @PreAuthorize("#deciderId == authentication.principal.userId")
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
             noRetryFor = BusinessException.class,
@@ -278,7 +279,12 @@ public class ApplicationServiceImpl implements ApplicationService {
         application.delete();
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+            retryFor = TransientDataAccessException.class, // 일시적 DB 문제
+            noRetryFor = BusinessException.class,
+            maxAttempts = 3
+    )
     @Override
     public void cancelApplication(Long recruitmentId) {
         applicationRepository.updateStatusAllByRecruitmentId(
@@ -288,7 +294,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         );
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Retryable(
             retryFor = TransientDataAccessException.class, // 일시적 DB 문제
             noRetryFor = BusinessException.class,

--- a/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/assignment/service/serviceImpl/AssignmentServiceImpl.java
@@ -17,6 +17,7 @@ import com.wagglex2.waggle.domain.assignment.service.AssignmentService;
 import com.wagglex2.waggle.domain.bookmark.service.BookmarkService;
 import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.common.event.SimpleRecruitmentCreatedEvent;
+import com.wagglex2.waggle.domain.common.event.RecruitmentReopenedEvent;
 import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import com.wagglex2.waggle.domain.common.event.RecruitmentDeletedEvent;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
@@ -204,7 +205,15 @@ public class AssignmentServiceImpl implements AssignmentService {
             return;
         }
 
+        RecruitmentStatus before = assignment.getStatus();
         assignment.update(updateDto);
+        RecruitmentStatus after = assignment.getStatus();
+
+        // 마감일 수정에 의해 모집이 재개 경우
+        if (before == RecruitmentStatus.CLOSED
+                && after == RecruitmentStatus.RECRUITING) {
+            publisher.publishEvent(new RecruitmentReopenedEvent(assignmentId));
+        }
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/wagglex2/waggle/domain/bookmark/repository/BookmarkRepository.java
@@ -36,5 +36,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Bookm
      */
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Bookmark b WHERE b.recruitment.id = :recruitmentId")
-    void deleteAllByRecruitmentId(Long recruitmentId);
+    int deleteAllByRecruitmentId(Long recruitmentId);
 }

--- a/src/main/java/com/wagglex2/waggle/domain/bookmark/service/serviceImpl/BookmarkServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/bookmark/service/serviceImpl/BookmarkServiceImpl.java
@@ -12,11 +12,16 @@ import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
 import com.wagglex2.waggle.domain.user.entity.User;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -24,6 +29,7 @@ import java.util.Optional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class BookmarkServiceImpl implements BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
@@ -81,9 +87,26 @@ public class BookmarkServiceImpl implements BookmarkService {
         bookmarkRepository.delete(bookmark);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+            retryFor = TransientDataAccessException.class, // 일시적 DB 문제
+            noRetryFor = BusinessException.class,
+            maxAttempts = 3
+    )
     @Override
     public void deleteAllByRecruitmentId(Long recruitmentId) {
-        bookmarkRepository.deleteAllByRecruitmentId(recruitmentId);
+        int deleted = bookmarkRepository.deleteAllByRecruitmentId(recruitmentId);
+
+        log.info("[찜 삭제] 공고 삭제에 따른 찜 삭제 건수: {} (recruitmentId={})",
+                deleted, recruitmentId);
+    }
+
+    /**
+     * 이벤트 처리 재시도 실패 시 처리
+     */
+    @Recover
+    protected void recoverEvent(TransientDataAccessException e, Long recruitmentId) {
+        log.error("공고 삭제에 따른 찜 삭제 실패(재시도 모두 실패) (recruitmentId={}, 예외타입={}, 메시지={})",
+                recruitmentId, e.getClass().getSimpleName(), e.getMessage(), e);
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/common/event/RecruitmentReopenedEvent.java
+++ b/src/main/java/com/wagglex2/waggle/domain/common/event/RecruitmentReopenedEvent.java
@@ -1,0 +1,3 @@
+package com.wagglex2.waggle.domain.common.event;
+
+public record RecruitmentReopenedEvent(Long recruitmentId) { }

--- a/src/main/java/com/wagglex2/waggle/domain/notification/service/serviceImpl/NotificationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/service/serviceImpl/NotificationServiceImpl.java
@@ -12,11 +12,16 @@ import com.wagglex2.waggle.domain.notification.service.NotificationService;
 import com.wagglex2.waggle.domain.notification.type.NotificationType;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
@@ -24,6 +29,7 @@ import java.util.Set;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationServiceImpl implements NotificationService {
 
     private static final Set<String> NOTIFICATION_SORT_FIELDS = Set.of("createdAt");
@@ -32,7 +38,12 @@ public class NotificationServiceImpl implements NotificationService {
     private final ApplicationService applicationService;
     private final PageableValidator pageableValidator;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+            retryFor = TransientDataAccessException.class, // 일시적 DB 문제
+            noRetryFor = BusinessException.class,
+            maxAttempts = 3
+    )
     @Override
     public void createNotification(Long senderId, Long receiverId, Long applicationId, NotificationType type) {
         Notification newNotification = new Notification(
@@ -43,6 +54,9 @@ public class NotificationServiceImpl implements NotificationService {
         );
 
         notificationRepository.save(newNotification);
+
+        log.info("[알림 생성] 새 알림 생성 (senderId={}, receiverId={}, applicationId={}, type={})",
+                senderId, receiverId, applicationId, type);
     }
 
     @PreAuthorize("#receiverId == authentication.principal.userId")
@@ -105,5 +119,20 @@ public class NotificationServiceImpl implements NotificationService {
 
         // 카테고리별 삭제
         notificationRepository.deleteAllByReceiverIdAndCategory(receiverId, category);
+    }
+
+    /**
+     * 이벤트 처리 재시도 실패 시 처리
+     */
+    @Recover
+    protected void recoverEvent(
+            TransientDataAccessException e,
+            Long senderId,
+            Long receiverId,
+            Long applicationId,
+            NotificationType type
+    ) {
+        log.error("알림 생성 실패(재시도 모두 실패) (senderId={}, receiverId={}, applicationId={}, type={})",
+                senderId, receiverId, applicationId, type);
     }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/project/service/serviceImpl/ProjectServiceImpl.java
@@ -9,6 +9,7 @@ import com.wagglex2.waggle.domain.application.service.ApplicationService;
 import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.bookmark.service.BookmarkService;
 import com.wagglex2.waggle.domain.common.type.PositionType;
+import com.wagglex2.waggle.domain.common.event.RecruitmentReopenedEvent;
 import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import com.wagglex2.waggle.domain.common.event.RecruitmentDeletedEvent;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
@@ -235,7 +236,15 @@ public class ProjectServiceImpl implements ProjectService {
             return;
         }
 
+        RecruitmentStatus before = project.getStatus();
         project.update(updateDto);
+        RecruitmentStatus after = project.getStatus();
+
+        // 마감일 수정에 의해 모집이 재개 경우
+        if (before == RecruitmentStatus.CLOSED
+                && after == RecruitmentStatus.RECRUITING) {
+            publisher.publishEvent(new RecruitmentReopenedEvent(projectId));
+        }
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")

--- a/src/main/java/com/wagglex2/waggle/domain/study/service/serviceImpl/StudyServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/study/service/serviceImpl/StudyServiceImpl.java
@@ -9,6 +9,7 @@ import com.wagglex2.waggle.domain.application.service.ApplicationService;
 import com.wagglex2.waggle.domain.common.dto.response.RecruitmentWithAppsResponseDto;
 import com.wagglex2.waggle.domain.bookmark.service.BookmarkService;
 import com.wagglex2.waggle.domain.common.event.SimpleRecruitmentCreatedEvent;
+import com.wagglex2.waggle.domain.common.event.RecruitmentReopenedEvent;
 import com.wagglex2.waggle.domain.common.event.RecruitmentDeletedEvent;
 import com.wagglex2.waggle.domain.common.type.RecruitmentCategory;
 import com.wagglex2.waggle.domain.common.type.RecruitmentStatus;
@@ -206,7 +207,15 @@ public class StudyServiceImpl implements StudyService {
             return;
         }
 
+        RecruitmentStatus before = study.getStatus();
         study.update(updateDto);
+        RecruitmentStatus after = study.getStatus();
+
+        // 마감일 수정에 의해 모집이 재개 경우
+        if (before == RecruitmentStatus.CLOSED
+                && after == RecruitmentStatus.RECRUITING) {
+            publisher.publishEvent(new RecruitmentReopenedEvent(studyId));
+        }
     }
 
     @PreAuthorize("#userId == authentication.principal.userId")


### PR DESCRIPTION
해당 트랜잭션에 대해 DB 접근 오류에 대해서만 재시도 처리, 그 외의 다른 트랜잭션과의 충돌은 고려하지 않음.

이유:

- 해당 트랜잭션과 겹칠 수 있는 트랜잭션의 종류: `accept`, `reject` `cancel`, `delete`
- `accept`, `reject` `cancel`는 같은 컬럼(`status`)을 수정하지만 해당 이벤트를 발행하는 주체가 공고 게시자로 유일하기 때문에 사실상 정합성 문제 가능성 낮음.
- `delete`의 주체는 지원자로 트랜잭션 자체는 겹칠 수 있으나, 서로 다른 컬럼을 수정하기 때문에 고려하지 않음.