### PR TITLE
Merge | Fix: 회원가입 시 학교 도메인 예외 처리 [BE-191]

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/wagglex2/waggle/domain/auth/controller/docs/AuthControllerDocs.java
@@ -89,6 +89,15 @@ public interface AuthControllerDocs {
                                                         ]
                                                     }
                                                     """
+                                    ),
+                                    @ExampleObject(
+                                            name = "지원하지 않는 학교 이메일",
+                                            value = """
+                                                    {
+                                                        "code": "UNSUPPORTED_UNIVERSITY_DOMAIN",
+                                                        "message": "지원하지 않는 학교 도메인입니다."
+                                                    }
+                                                    """
                                     )
                             }
                     )

--- a/src/main/java/com/wagglex2/waggle/domain/auth/service/serviceImpl/AuthServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/auth/service/serviceImpl/AuthServiceImpl.java
@@ -9,6 +9,7 @@ import com.wagglex2.waggle.domain.auth.dto.response.SignInResult;
 import com.wagglex2.waggle.domain.auth.dto.response.TokenPair;
 import com.wagglex2.waggle.domain.auth.service.AuthService;
 import com.wagglex2.waggle.domain.user.entity.User;
+import com.wagglex2.waggle.domain.user.entity.type.University;
 import com.wagglex2.waggle.domain.user.service.UserService;
 import io.lettuce.core.RedisConnectionException;
 import jakarta.mail.MessagingException;
@@ -68,6 +69,8 @@ public class AuthServiceImpl implements AuthService {
      */
     @Override
     public void sendAuthCode(String toEmail) {
+
+        University.fromEmail(toEmail);
 
         try {
             // 1. 랜덤 6자리 인증번호 생성
@@ -187,6 +190,9 @@ public class AuthServiceImpl implements AuthService {
         } catch (RedisConnectionException e) {
             log.error("Redis 연결 실패 : {}", e.getMessage());
             throw new BusinessException(ErrorCode.REDIS_CONNECTION_ERROR);
+        } catch (BusinessException e) {
+            log.error("인증번호 오류 : {}", e.getMessage());
+            throw new BusinessException(e.getErrorCode());
         } catch (Exception e) {
             log.error("인증번호 검증 도중 오류 발생 : {]", e.getMessage());
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
회원가입 화면에서 이메일란에 학교 도메인이 아닌 다른 도메인(ex. gmail.com, ynu.ac.kr)을 작성했을 때 예외 처리를 추가했음.