### PR TITLE
fix: BusinessException에 대한 recover 메서드 추가

### DIFF
--- a/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/application/service/serviceImpl/ApplicationServiceImpl.java
@@ -398,4 +398,9 @@ public class ApplicationServiceImpl implements ApplicationService {
         log.error("공고 삭제 및 재개에 따른 지원 상태 업데이트 실패(재시도 모두 실패) (recruitmentId={}, 예외타입={}, 메시지={})",
                 recruitmentId, e.getClass().getSimpleName(), e.getMessage(), e);
     }
+
+    @Recover
+    protected void recover(BusinessException e) {
+        throw e;
+    }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/bookmark/service/serviceImpl/BookmarkServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/bookmark/service/serviceImpl/BookmarkServiceImpl.java
@@ -109,4 +109,9 @@ public class BookmarkServiceImpl implements BookmarkService {
         log.error("공고 삭제에 따른 찜 삭제 실패(재시도 모두 실패) (recruitmentId={}, 예외타입={}, 메시지={})",
                 recruitmentId, e.getClass().getSimpleName(), e.getMessage(), e);
     }
+
+    @Recover
+    protected void recover(BusinessException e) {
+        throw e;
+    }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/notification/service/serviceImpl/NotificationServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/notification/service/serviceImpl/NotificationServiceImpl.java
@@ -135,4 +135,9 @@ public class NotificationServiceImpl implements NotificationService {
         log.error("알림 생성 실패(재시도 모두 실패) (senderId={}, receiverId={}, applicationId={}, type={})",
                 senderId, receiverId, applicationId, type);
     }
+
+    @Recover
+    protected void recover(BusinessException e) {
+        throw e;
+    }
 }

--- a/src/main/java/com/wagglex2/waggle/domain/team_member/service/serviceImpl/TeamMemberServiceImpl.java
+++ b/src/main/java/com/wagglex2/waggle/domain/team_member/service/serviceImpl/TeamMemberServiceImpl.java
@@ -89,4 +89,9 @@ public class TeamMemberServiceImpl implements TeamMemberService {
     protected void recover(ObjectOptimisticLockingFailureException e, Long teamId, Long removerId, Long targetId) {
         throw new BusinessException(ErrorCode.TOO_MANY_REQUESTS);
     }
+
+    @Recover
+    protected void recover(BusinessException e) {
+        throw e;
+    }
 }


### PR DESCRIPTION
### 문제

- 기존 코드에서는 `BusinessException`을 처리할 `@Recover` 메서드가 없었기 때문에 `Cannot locate recovery method` 오류가 발생
- 그로 인해 API 응답으로 `INTERNAL_SERVER_ERROR`가 응답되었음


### 해결

- `BusinessException` 처리용 `@Recover` 메서드를 추가하고, 해당 예외를 그대로 throw 하도록 하여 이를 해결